### PR TITLE
revert to PyTorch 1.11 to simplify conda env creation

### DIFF
--- a/LibTorchSharp/LibTorchSharp/THSAutograd.cpp
+++ b/LibTorchSharp/LibTorchSharp/THSAutograd.cpp
@@ -16,5 +16,5 @@ void THSAutograd_setGrad(bool enabled)
 
 void THSAutograd_setInference(bool enabled)
 {
-    c10::AutogradState::set_tls_state(c10::AutogradState(!enabled, enabled, !enabled, enabled));
+    c10::AutogradState::set_tls_state(c10::AutogradState(!enabled, enabled, !enabled));
 }

--- a/warp_build.yml
+++ b/warp_build.yml
@@ -6,9 +6,12 @@ dependencies:
   - torchvision
   - libtiff
   - python
-  - cuda-version=11.8
-  - pytorch>2
+  - pytorch=1.11
+  - pytorch-gpu
   - fftw
   - cmake
   - cxx-compiler=1.3
   - dotnet=8.0
+  - cudatoolkit
+  - cudatoolkit-dev
+  - cudnn


### PR DESCRIPTION
closes #15 