### PR TITLE
Add debug output to `ts_export_particles`

### DIFF
--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -197,14 +197,14 @@ namespace WarpTools.Commands
                         Console.WriteLine($"no particles found in {tiltSeries.Name}");
                     return;
                 }
-                    
-
+                
                 // Get positions and orientations for this tilt-series, rescale to Angstroms
                 List<int> TSParticleIndices = TiltSeriesIDToParticleIndices[tiltSeries.Name];
                 float3[] TSParticleXYZAngstroms = new float3[TSParticleIndices.Count];
                 float3[] TSParticleRotTiltPsi = new float3[TSParticleIndices.Count];
                 
-                Console.WriteLine($"{TSParticleIndices.Count} particles for {TiltSeries.Name}");
+                if (Environment.GetEnvironmentVariable("WARP_DEBUG") != null)
+                    Console.WriteLine($"{TSParticleIndices.Count} particles for {TiltSeries.Name}");
 
                 for (int i = 0; i < TSParticleIndices.Count; i++)
                 {

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -186,7 +186,7 @@ namespace WarpTools.Commands
             {
                 TiltSeries TiltSeries = (TiltSeries)tiltSeries;
                 if (Environment.GetEnvironmentVariable("WARP_DEBUG") != null)
-                    Console.WriteLine($"Processing {tiltSeries.Name}");
+                    Console.WriteLine($"\nProcessing {tiltSeries.Name}");
 
                 // Validate presence of CTF info and particles for this TS, early exit if not found
                 if (tiltSeries.OptionsCTF == null)
@@ -194,7 +194,7 @@ namespace WarpTools.Commands
                 if (!TiltSeriesIDToParticleIndices.ContainsKey(tiltSeries.Name))
                 {
                     if (Environment.GetEnvironmentVariable("WARP_DEBUG") != null)
-                        Console.WriteLine($"no particles found in {tiltSeries.Name}");
+                        Console.WriteLine($"\nno particles found in {tiltSeries.Name}");
                     return;
                 }
                 
@@ -204,7 +204,7 @@ namespace WarpTools.Commands
                 float3[] TSParticleRotTiltPsi = new float3[TSParticleIndices.Count];
                 
                 if (Environment.GetEnvironmentVariable("WARP_DEBUG") != null)
-                    Console.WriteLine($"{TSParticleIndices.Count} particles for {TiltSeries.Name}");
+                    Console.WriteLine($"\n{TSParticleIndices.Count} particles for {TiltSeries.Name}");
 
                 for (int i = 0; i < TSParticleIndices.Count; i++)
                 {

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -141,10 +141,14 @@ namespace WarpTools.Commands
             Dictionary<string, List<int>> TiltSeriesIDToParticleIndices = GroupParticles(
                 tiltSeriesIDs: InputStar.GetColumn("rlnMicrographName")
             );
-            foreach (var kvp in TiltSeriesIDToParticleIndices)
+            if (Environment.GetEnvironmentVariable("WARP_DEBUG") != null)
             {
-                Console.WriteLine($"TS: {kvp.Key}   Particles: {kvp.Value.Count}");
+                foreach (var kvp in TiltSeriesIDToParticleIndices)
+                {
+                    Console.WriteLine($"TS: {kvp.Key}   Particles: {kvp.Value.Count}");
+                }
             }
+            
             float3[] InputXYZ = GetInputCoordinates(InputStar);
             float3[]? InputEulerAnglesRotTiltPsi = GetInputEulerAngles(InputStar); // degrees
 
@@ -181,14 +185,16 @@ namespace WarpTools.Commands
             IterateOverItems(Workers, CLI, (worker, tiltSeries) =>
             {
                 TiltSeries TiltSeries = (TiltSeries)tiltSeries;
-                Console.WriteLine($"Processing {tiltSeries.Name}");
+                if (Environment.GetEnvironmentVariable("WARP_DEBUG") != null)
+                    Console.WriteLine($"Processing {tiltSeries.Name}");
 
                 // Validate presence of CTF info and particles for this TS, early exit if not found
                 if (tiltSeries.OptionsCTF == null)
                     return;
                 if (!TiltSeriesIDToParticleIndices.ContainsKey(tiltSeries.Name))
                 {
-                    Console.WriteLine($"no particles found in {tiltSeries.Name}");
+                    if (Environment.GetEnvironmentVariable("WARP_DEBUG") != null)
+                        Console.WriteLine($"no particles found in {tiltSeries.Name}");
                     return;
                 }
                     

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -1,6 +1,7 @@
 using CommandLine;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -140,6 +141,10 @@ namespace WarpTools.Commands
             Dictionary<string, List<int>> TiltSeriesIDToParticleIndices = GroupParticles(
                 tiltSeriesIDs: InputStar.GetColumn("rlnMicrographName")
             );
+            foreach (var kvp in TiltSeriesIDToParticleIndices)
+            {
+                Console.WriteLine($"TS: {kvp.Key}   Particles: {kvp.Value.Count}");
+            }
             float3[] InputXYZ = GetInputCoordinates(InputStar);
             float3[]? InputEulerAnglesRotTiltPsi = GetInputEulerAngles(InputStar); // degrees
 
@@ -176,17 +181,24 @@ namespace WarpTools.Commands
             IterateOverItems(Workers, CLI, (worker, tiltSeries) =>
             {
                 TiltSeries TiltSeries = (TiltSeries)tiltSeries;
+                Console.WriteLine($"Processing {tiltSeries.Name}");
 
                 // Validate presence of CTF info and particles for this TS, early exit if not found
                 if (tiltSeries.OptionsCTF == null)
                     return;
                 if (!TiltSeriesIDToParticleIndices.ContainsKey(tiltSeries.Name))
+                {
+                    Console.WriteLine($"no particles found in {tiltSeries.Name}");
                     return;
+                }
+                    
 
                 // Get positions and orientations for this tilt-series, rescale to Angstroms
                 List<int> TSParticleIndices = TiltSeriesIDToParticleIndices[tiltSeries.Name];
                 float3[] TSParticleXYZAngstroms = new float3[TSParticleIndices.Count];
                 float3[] TSParticleRotTiltPsi = new float3[TSParticleIndices.Count];
+                
+                Console.WriteLine($"{TSParticleIndices.Count} particles for {TiltSeries.Name}");
 
                 for (int i = 0; i < TSParticleIndices.Count; i++)
                 {


### PR DESCRIPTION
in bash `export WARP_DEBUG=1` yields output like:

```txt
Found 5 files in warp_tiltseries/matching matching *15854_clean.star;
TS: TS_32.tomostar   Particles: 248
TS: TS_11.tomostar   Particles: 310
TS: TS_17.tomostar   Particles: 142
TS: TS_1.tomostar   Particles: 250
TS: TS_23.tomostar   Particles: 222
Found 1172 particles in 5 tilt series
Connecting to workers...
Connected to 1 workers
0/5Processing TS_11.tomostar
310 particles for TS_11.tomostar
1/5, 00:14 remainingProcessing TS_1.tomostar                                                                                                       
250 particles for TS_1.tomostar
2/5, 00:10 remainingProcessing TS_17.tomostar                                                                                                      
142 particles for TS_17.tomostar
3/5, 00:06 remainingProcessing TS_32.tomostar                                                                                                      
248 particles for TS_32.tomostar
4/5, 00:03 remainingProcessing TS_23.tomostar                                                                                                      
222 particles for TS_23.tomostar
5/5, 00:00 remaining                                                                                                                               
Finished processing in 00:00:17
```

closes #51 