### PR TITLE
add AreTomo2 compatibility

### DIFF
--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -1273,6 +1273,14 @@ namespace Warp
                     IOPath.Combine(ResultsDir, RootName.Replace(".mrc", "") + "_Imod", RootName.Replace(".mrc", "") + ".xf"),
                     IOPath.Combine(ResultsDir, RootName.Replace(".mrc", "") + "_Imod", RootName.Replace(".mrc", "") + "_st.xf"),
                 };
+                if (Environment.GetEnvironmentVariable("WARP_DEBUG") != null)
+                {
+                    Console.WriteLine("Possible XF file paths:");
+                    foreach (string path in XfPaths)
+                    {
+                        Console.WriteLine($"{path}");
+                    }
+                }
                 string XfPath = null;
                 try
                 {

--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -1270,12 +1270,14 @@ namespace Warp
                     IOPath.Combine(ResultsDir, RootName + "_Imod", RootName + ".xf"),
                     IOPath.Combine(ResultsDir, RootName.Replace(".mrc", "") + ".xf"),
                     IOPath.Combine(ResultsDir, "../", RootName.Replace(".mrc", "") + ".xf"),
-                    IOPath.Combine(ResultsDir, RootName.Replace(".mrc", "") + "_Imod", RootName.Replace(".mrc", "") + ".xf"),
+                    IOPath.Combine(ResultsDir, RootName.Replace(".mrc", "") + "_Imod", RootName.Replace(".mrc", "") + ".xf")
+                    IOPath.Combine(ResultsDir, RootName.Replace(".mrc", "") + "_Imod", RootName.Replace(".mrc", "") + "_st.xf"),
                 };
                 string XfPath = null;
                 try
                 {
                     XfPath = XfPaths.First(s => File.Exists(s));
+                    Console.WriteLine($"Importing 2D transforms from {XfPath}");
                 }
                 catch { }
                 if (XfPath == null)

--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -1270,7 +1270,7 @@ namespace Warp
                     IOPath.Combine(ResultsDir, RootName + "_Imod", RootName + ".xf"),
                     IOPath.Combine(ResultsDir, RootName.Replace(".mrc", "") + ".xf"),
                     IOPath.Combine(ResultsDir, "../", RootName.Replace(".mrc", "") + ".xf"),
-                    IOPath.Combine(ResultsDir, RootName.Replace(".mrc", "") + "_Imod", RootName.Replace(".mrc", "") + ".xf")
+                    IOPath.Combine(ResultsDir, RootName.Replace(".mrc", "") + "_Imod", RootName.Replace(".mrc", "") + ".xf"),
                     IOPath.Combine(ResultsDir, RootName.Replace(".mrc", "") + "_Imod", RootName.Replace(".mrc", "") + "_st.xf"),
                 };
                 string XfPath = null;

--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -1267,14 +1267,14 @@ namespace Warp
                 string[] FileNames =
                 {
                     $"{RootName}.xf",
-                    $"{RootName.Replace(".mrc", "")}.xf"
+                    $"{RootName.Replace(".mrc", "")}.xf",
                     $"{RootName}_st.xf",
                     $"{RootName.Replace(".mrc", "")}_st.xf"
                 };
                 string[] XfPaths = new string[Directories.Length * FileNames.Length];
-                for (int i=0; i++; i < Directories.Length)
+                for (int i=0; i < Directories.Length, i++)
                 {
-                    foreach (int j=0; j++; j < FileNames.Length)
+                    for (int j=0; j < FileNames.Length, j++)
                     {
                         idx = i * FileNames.Length + j;
                         Console.WriteLine("idx");

--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -1263,16 +1263,35 @@ namespace Warp
 
             // .xf
             {
-                string[] XfPaths = 
+                string[] Directories = {"", "../", $"{RootName}_Imod", $"../{RootName}_Imod" };
+                string[] FileNames =
                 {
-                    IOPath.Combine(ResultsDir, RootName + ".xf"),
-                    IOPath.Combine(ResultsDir, "../", RootName + ".xf"),
-                    IOPath.Combine(ResultsDir, RootName + "_Imod", RootName + ".xf"),
-                    IOPath.Combine(ResultsDir, RootName.Replace(".mrc", "") + ".xf"),
-                    IOPath.Combine(ResultsDir, "../", RootName.Replace(".mrc", "") + ".xf"),
-                    IOPath.Combine(ResultsDir, RootName.Replace(".mrc", "") + "_Imod", RootName.Replace(".mrc", "") + ".xf"),
-                    IOPath.Combine(ResultsDir, RootName.Replace(".mrc", "") + "_Imod", RootName.Replace(".mrc", "") + "_st.xf"),
+                    $"{RootName}.xf",
+                    $"{RootName.Replace(".mrc", "")}.xf"
+                    $"{RootName}_st.xf",
+                    $"{RootName.Replace(".mrc", "")}_st.xf"
                 };
+                string[] XfPaths = new string[Directories.Length * FileNames.Length];
+                for (int i=0; i++; i < Directories.Length)
+                {
+                    foreach (int j=0; j++; j < FileNames.Length)
+                    {
+                        idx = i * FileNames.Length + j;
+                        Console.WriteLine("idx");
+                        XfPaths[idx] = IOPath.Combine(ResultsDir, Directories[i], FileNames[j])
+                    }
+                        
+                }
+                // string[] XfPaths = 
+                // {
+                //     IOPath.Combine(ResultsDir, RootName + ".xf"),
+                //     IOPath.Combine(ResultsDir, "../", RootName + ".xf"),
+                //     IOPath.Combine(ResultsDir, RootName + "_Imod", RootName + ".xf"),
+                //     IOPath.Combine(ResultsDir, RootName.Replace(".mrc", "") + ".xf"),
+                //     IOPath.Combine(ResultsDir, "../", RootName.Replace(".mrc", "") + ".xf"),
+                //     IOPath.Combine(ResultsDir, RootName.Replace(".mrc", "") + "_Imod", RootName.Replace(".mrc", "") + ".xf"),
+                //     IOPath.Combine(ResultsDir, RootName.Replace(".mrc", "") + "_Imod", RootName.Replace(".mrc", "") + "_st.xf"),
+                // };
                 if (Environment.GetEnvironmentVariable("WARP_DEBUG") != null)
                 {
                     Console.WriteLine("Possible XF file paths:");

--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -1272,9 +1272,9 @@ namespace Warp
                     $"{RootName.Replace(".mrc", "")}_st.xf"
                 };
                 string[] XfPaths = new string[Directories.Length * FileNames.Length];
-                for (int i=0; i < Directories.Length;, i++)
+                for (int i=0; i < Directories.Length; i++)
                 {
-                    for (int j=0; j < FileNames.Length;, j++)
+                    for (int j=0; j < FileNames.Length; j++)
                     {
                         idx = i * FileNames.Length + j;
                         Console.WriteLine("idx");

--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -1294,7 +1294,7 @@ namespace Warp
                 try
                 {
                     XfPath = XfPaths.First(s => File.Exists(s));
-                    Console.WriteLine($"Importing 2D transforms from {XfPath}");
+                    Console.WriteLine($"\nImporting 2D transforms from {XfPath}");
                 }
                 catch { }
                 if (XfPath == null)

--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -1272,9 +1272,9 @@ namespace Warp
                     $"{RootName.Replace(".mrc", "")}_st.xf"
                 };
                 string[] XfPaths = new string[Directories.Length * FileNames.Length];
-                for (int i=0; i < Directories.Length, i++);
+                for (int i=0; i < Directories.Length;, i++)
                 {
-                    for (int j=0; j < FileNames.Length, j++);
+                    for (int j=0; j < FileNames.Length;, j++)
                     {
                         idx = i * FileNames.Length + j;
                         Console.WriteLine("idx");

--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -1272,13 +1272,14 @@ namespace Warp
                     $"{RootName.Replace(".mrc", "")}_st.xf"
                 };
                 string[] XfPaths = new string[Directories.Length * FileNames.Length];
-                for (int i=0; i < Directories.Length, i++)
+                for (int i=0; i < Directories.Length, i++);
                 {
-                    for (int j=0; j < FileNames.Length, j++)
+                    for (int j=0; j < FileNames.Length, j++);
                     {
                         idx = i * FileNames.Length + j;
                         Console.WriteLine("idx");
-                        XfPaths[idx] = IOPath.Combine(ResultsDir, Directories[i], FileNames[j])
+                        XfPaths[idx] = IOPath.Combine(ResultsDir, Directories[i],
+                            FileNames[j]);
                     }
                         
                 }

--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -1278,22 +1278,10 @@ namespace Warp
                     for (int j=0; j < FileNames.Length; j++)
                     {
                         idx = i * FileNames.Length + j;
-                        Console.WriteLine("idx");
-                        XfPaths[idx] = IOPath.Combine(ResultsDir, Directories[i],
-                            FileNames[j]);
+                        XfPaths[idx] = Path.GetFullPath(IOPath.Combine(ResultsDir, Directories[i], FileNames[j]));
                     }
                         
                 }
-                // string[] XfPaths = 
-                // {
-                //     IOPath.Combine(ResultsDir, RootName + ".xf"),
-                //     IOPath.Combine(ResultsDir, "../", RootName + ".xf"),
-                //     IOPath.Combine(ResultsDir, RootName + "_Imod", RootName + ".xf"),
-                //     IOPath.Combine(ResultsDir, RootName.Replace(".mrc", "") + ".xf"),
-                //     IOPath.Combine(ResultsDir, "../", RootName.Replace(".mrc", "") + ".xf"),
-                //     IOPath.Combine(ResultsDir, RootName.Replace(".mrc", "") + "_Imod", RootName.Replace(".mrc", "") + ".xf"),
-                //     IOPath.Combine(ResultsDir, RootName.Replace(".mrc", "") + "_Imod", RootName.Replace(".mrc", "") + "_st.xf"),
-                // };
                 if (Environment.GetEnvironmentVariable("WARP_DEBUG") != null)
                 {
                     Console.WriteLine("Possible XF file paths:");

--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -1272,6 +1272,7 @@ namespace Warp
                     $"{RootName.Replace(".mrc", "")}_st.xf"
                 };
                 string[] XfPaths = new string[Directories.Length * FileNames.Length];
+                int idx;
                 for (int i=0; i < Directories.Length; i++)
                 {
                     for (int j=0; j < FileNames.Length; j++)

--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -1278,7 +1278,7 @@ namespace Warp
                     for (int j=0; j < FileNames.Length; j++)
                     {
                         idx = i * FileNames.Length + j;
-                        XfPaths[idx] = Path.GetFullPath(IOPath.Combine(ResultsDir, Directories[i], FileNames[j]));
+                        XfPaths[idx] = IOPath.GetFullPath(IOPath.Combine(ResultsDir, Directories[i], FileNames[j]));
                     }
                         
                 }

--- a/WarpTools/Commands/Tiltseries/AreTomoTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/AreTomoTiltseries.cs
@@ -11,7 +11,7 @@ using Warp.Tools;
 namespace WarpTools.Commands
 {
     [VerbGroup("Tilt series")]
-    [Verb("ts_aretomo", HelpText = "Create tilt series stacks and run AreTomo to obtain tilt series alignments")]
+    [Verb("ts_aretomo", HelpText = "Create tilt series stacks and run AreTomo2 to obtain tilt series alignments")]
     [CommandRunner(typeof(AreTomoTiltseries))]
     class AreTomoTiltseriesOptions : DistributedOptions
     {
@@ -36,7 +36,7 @@ namespace WarpTools.Commands
         [Option("delete_intermediate", HelpText = "Delete tilt series stacks generated for AreTomo")]
         public bool DeleteIntermediate { get; set; }
 
-        [Option("exe", Default = "AreTomo", HelpText = "Name of the AreTomo executable; must be in $PATH")]
+        [Option("exe", Default = "AreTomo2", HelpText = "Name of the AreTomo2 executable; must be in $PATH")]
         public string Executable { get; set; }
     }
 

--- a/WarpTools/Commands/Tiltseries/ImportAlignmentsTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ImportAlignmentsTiltseries.cs
@@ -59,6 +59,8 @@ namespace WarpTools.Commands
                 try
                 {
                     OptionsImport.OverrideResultsDir = Path.Combine(CLI.AlignmentPath, series.RootName);
+                    if (Environment.GetEnvironmentVariable("WARP_DEBUG") != null)
+                        Console.WriteLine($"override results dir: {OptionsImport.OverrideResultsDir}");
                     series.ImportAlignments(OptionsImport);
                     series.SaveMeta();
 

--- a/WarpTools/Commands/Tiltseries/ImportAlignmentsTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ImportAlignmentsTiltseries.cs
@@ -47,8 +47,7 @@ namespace WarpTools.Commands
             #endregion
 
             var OptionsImport = (ProcessingOptionsTomoImportAlignments)Options.FillTomoProcessingBase(new ProcessingOptionsTomoImportAlignments());
-
-            OptionsImport.OverrideResultsDir = CLI.AlignmentPath;
+            
             OptionsImport.MinFOV = (decimal)CLI.MinFOV;
             OptionsImport.BinTimes = (decimal)Math.Log(CLI.AlignmentAngPix / (double)Options.Import.PixelSize, 2.0);
 
@@ -72,6 +71,7 @@ namespace WarpTools.Commands
                     NFailed++;
                     Console.WriteLine($"Failed to import alignments for {series.Name}: {exc.Message}");
                 }
+                
             }
         }
     }


### PR DESCRIPTION
this PR adds changes for AreTomo2 compatibility and some useful debug output gated behind `WARP_DEBUG=1`

The AreTomo2 API is ~identical to AreTomo but when run on a stack called `TS_11.st` we end up with results called `TS_11_st.xf` in the `TS_11_Imod` folder

I also changed the way combinations of directories/filenames are generated so that you can easily specify a single tilt series directory in `ts_import_alignments` to only update a specific tilt series

closes #46 

