### PR TITLE
Add support for running local alignments in AreTomo2

### DIFF
--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -10734,6 +10734,9 @@ namespace Warp
 
         [WarpSerializable]
         public string Executable { get; set; }
+        
+        [WarpSerializable]
+        public int[] NPatchesXY { get; set; }
     }
     
     [Serializable]

--- a/WarpTools/Commands/Tiltseries/AreTomoTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/AreTomoTiltseries.cs
@@ -32,7 +32,10 @@ namespace WarpTools.Commands
 
         [Option("axis", HelpText = "Override tilt axis angle with this value")]
         public double? AxisAngle { get; set; }
-
+        
+        [Option("patches", HelpText = "Number of patches for local alignments in X, Y, separated by 'x': e.g. 6x4. Increases processing time.")]
+        public string NPatchesXY { get; set; }
+        
         [Option("delete_intermediate", HelpText = "Delete tilt series stacks generated for AreTomo")]
         public bool DeleteIntermediate { get; set; }
 
@@ -83,7 +86,23 @@ namespace WarpTools.Commands
             var OptionsAretomo = (ProcessingOptionsTomoAretomo)Options.FillTomoProcessingBase(new ProcessingOptionsTomoAretomo());
             OptionsAretomo.Executable = CLI.Executable;
             OptionsAretomo.AlignZ = (int)Math.Round(CLI.AlignZ / OptionsStack.BinnedPixelSizeMean);
-
+            
+            if (!string.IsNullOrEmpty(CLI.NPatchesXY))
+            {
+                try
+                {
+                    var NPatchesXY = CLI.NPatchesXY.Split('x').Select(int.Parse).ToArray();
+                    OptionsAretomo.NPatchesXY = NPatchesXY;
+                }
+                catch
+                {
+                    throw new Exception("Patch grid dimensions must be specified as XxY, e.g. 5x5");
+                }
+            }
+            else
+            {
+                OptionsAretomo.NPatchesXY = new int[] { 0, 0 };
+            }
             #endregion
 
             WorkerWrapper[] Workers = CLI.GetWorkers();

--- a/WarpWorker/WarpWorker.cs
+++ b/WarpWorker/WarpWorker.cs
@@ -349,8 +349,10 @@ namespace WarpWorker
                     string OutStack = T.RootName + "_aligned.mrc";
                     string Axis = Options.AxisAngle.ToString() + (Options.DoAxisSearch ? " 0" : " -1");
                     string AlignZ = Options.AlignZ.ToString();
+                    string NPatchesX = Options.NPatchesXY[0].ToString();
+                    string NPatchesY = Options.NPatchesXY[1].ToString();
 
-                    string Arguments = $"-InMrc {StackPath} -AngFile {AnglePath} -VolZ 0 -OutBin 0 -TiltAxis {Axis} -AlignZ {AlignZ} -TiltCor 1 -OutImod 1 -DarkTol 0 -OutMrc {OutStack} -Gpu {DeviceID}";
+                    string Arguments = $"-InMrc {StackPath} -AngFile {AnglePath} -VolZ 0 -OutBin 0 -TiltAxis {Axis} -AlignZ {AlignZ} -TiltCor 1 -OutImod 1 -DarkTol 0 -OutMrc {OutStack} -Gpu {DeviceID} -Patch {NPatchesX} {NPatchesY}";
 
                     Console.WriteLine($"Executing {Options.Executable} in {StackDir} with arguments: {Arguments}");
 


### PR DESCRIPTION
@jmdobbs reported in #78 that running AreTomo with local alignments improves performance in some cases even when local alignments are not used for downstream processing - presumably this is due to being able to ignore poor areas of images because of the smart grid

In my tests on EMPIAR 10491, turning local alignments on failed on the tilt series it fails on without local alignments and didn't massively change things for the others - maybe slightly better

<img width="600" alt="image" src="https://github.com/warpem/warp/assets/7307488/fb933567-052a-40de-9d2a-7402aa4857fc">
