### PR TITLE
Revert "Don't miss exceptions from processing"

### DIFF
--- a/MCore/MCore.cs
+++ b/MCore/MCore.cs
@@ -41,7 +41,7 @@ namespace MCore
 
         public static Task ProcessingTask;
 
-        static async Task Main(string[] args)
+        static void Main(string[] args)
         {
             CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
             CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
@@ -88,7 +88,7 @@ namespace MCore
                                   .UseStartup<RESTStartup>()
                                   .ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Warning));
                     }).Build();
-                    await RESTHost.RunAsync();
+                    RESTHost.RunAsync();
                 }
                 catch (Exception exc)
                 {
@@ -98,9 +98,12 @@ namespace MCore
 
             #endregion
 
-            await DoProcessing();
+            ProcessingTask = new Task(DoProcessing);
+            ProcessingTask.Start();
 
-            RESTHost?.StopAsync().Wait();
+            while (AppRunning) Thread.Sleep(1);
+
+            RESTHost.StopAsync().Wait();
         }
 
         static void SetOptionsFromCLI(OptionsCLI cli)
@@ -266,7 +269,7 @@ namespace MCore
 
         #endregion
 
-        static async Task DoProcessing()
+        static void DoProcessing()
         {
             Console.Write("Loading population... ");
             if (!File.Exists(Path.Combine(WorkingDirectory, OptionsCLI.Population)))


### PR DESCRIPTION
This reverts commit c2835b5f0603bdce7add4459091b25ae0c0aa2d7 and closes #101 .

Tested and working

```sh
MCore --population m/10491.population --perdevice_refine 4 --iter 0
```
```
Loading population... Done
Creating directories... Done
Spawning workers... Done
Preparing for refinement – this will take a few minutes per species
Preparing refinement requisites...
1/1                                                                                                                            
Performing refinement
Preparing population for data source 10491...Done
Loading gain reference for 10491... Done
Refining all series in data source...
5/5                                                                                                                            
Commiting changes in 10491...Done
Saving intermediate refinement results for 10491...Done
Finishing refinement
Gathering intermediate results, then reconstructing and filtering...
apoferritin: 4.17 Å                                                                                                            
1/1
```

cc @dtegunov we'll need to reintroduce the error catching you implemented here