### PR TITLE
catch At2 all zeros in tlt file bug and fail loudly

### DIFF
--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -1373,17 +1373,25 @@ namespace Warp
 
                 if (Lines.Length == NValid)
                 {
+                    float[] ParsedTiltAngles = new float[NTilts];
                     for (int t = 0, iline = 0; t < NTilts; t++)
                     {
-                        if (!UseTilt[t])
-                            continue;
-
                         string Line = Lines[iline];
-                        float Angle = float.Parse(Line, CultureInfo.InvariantCulture);
-
-                        Angles[t] = Angle;
-
+                        ParsedTiltAngles[t] = float.Parse(Line, CultureInfo.InvariantCulture);
                         iline++;
+                    }
+
+                    if (ParsedTiltAngles.Select(angle => { angle == 0 }).All())
+                        throw new Exception($"all tilt angles are zero in {TltPath}");
+                    else
+                    {
+                        for (int t = 0, iline = 0; t < NTilts; t++)
+                        {
+                            if (!UseTilt[t])
+                                continue;
+                            Angles[t] = ParsedTiltAngles[t];
+                            iline++;
+                        }
                     }
                 }
             }

--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -1380,7 +1380,7 @@ namespace Warp
                         ParsedTiltAngles[t] = float.Parse(Line, CultureInfo.InvariantCulture);
                     }
 
-                    if (ParsedTiltAngles.Select(angle => { angle == 0 }).All())
+                    if (ParsedTiltAngles.All(angle => angle == 0))
                         throw new Exception($"all tilt angles are zero in {TltPath}");
                     else
                     {

--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -1384,7 +1384,7 @@ namespace Warp
                         throw new Exception($"all tilt angles are zero in {TltPath}");
                     else
                     {
-                        for (int t = 0, t < NTilts; t++)
+                        for (int t = 0; t < NTilts; t++)
                         {
                             if (!UseTilt[t])
                                 continue;

--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -1374,23 +1374,21 @@ namespace Warp
                 if (Lines.Length == NValid)
                 {
                     float[] ParsedTiltAngles = new float[NTilts];
-                    for (int t = 0, iline = 0; t < NTilts; t++)
+                    for (int t = 0; t < NTilts; t++)
                     {
-                        string Line = Lines[iline];
+                        string Line = Lines[t];
                         ParsedTiltAngles[t] = float.Parse(Line, CultureInfo.InvariantCulture);
-                        iline++;
                     }
 
                     if (ParsedTiltAngles.Select(angle => { angle == 0 }).All())
                         throw new Exception($"all tilt angles are zero in {TltPath}");
                     else
                     {
-                        for (int t = 0, iline = 0; t < NTilts; t++)
+                        for (int t = 0, t < NTilts; t++)
                         {
                             if (!UseTilt[t])
                                 continue;
                             Angles[t] = ParsedTiltAngles[t];
-                            iline++;
                         }
                     }
                 }


### PR DESCRIPTION
closes #159 - not a fix but a workaround for an AT2 bug