### PR TITLE
Add missing path separator and handle null `TMPDIR`

### DIFF
--- a/WarpLib/WorkerWrapper.cs
+++ b/WarpLib/WorkerWrapper.cs
@@ -64,7 +64,7 @@ namespace Warp
                 // named pipes on linux don't work well on remote filesystems
                 // https://github.com/warpem/warp/issues/28#issuecomment-2197168677
                 string PipeDirectory = Environment.GetEnvironmentVariable("TMPDIR");
-                PipeName = $"{PipeDirectory}{PipeName}";
+                PipeName = Path.Combine(PipeDirectory, PipeName);
                 
                 if (Environment.GetEnvironmentVariable("WARP_DEBUG") != null)
                     StartInfo = new ProcessStartInfo()

--- a/WarpLib/WorkerWrapper.cs
+++ b/WarpLib/WorkerWrapper.cs
@@ -64,6 +64,10 @@ namespace Warp
                 // named pipes on linux don't work well on remote filesystems
                 // https://github.com/warpem/warp/issues/28#issuecomment-2197168677
                 string PipeDirectory = Environment.GetEnvironmentVariable("TMPDIR");
+                if (string.IsNullOrEmpty(PipeDirectory))
+                {
+                    PipeDirectory = "/tmp";
+                }
                 PipeName = Path.Combine(PipeDirectory, PipeName);
                 
                 if (Environment.GetEnvironmentVariable("WARP_DEBUG") != null)


### PR DESCRIPTION
fix from review by @jpellman in #166 - thanks again!