### PR TITLE
fix conda build and reorder release workflow steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-  
+
 jobs:
   deploy:
     name: Deploy
@@ -34,15 +34,10 @@ jobs:
           remove-android: 'true'
           remove-haskell: 'true'
           remove-codeql: 'true'
-        
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
-      - name: Release the source on GitHub
-        uses: softprops/action-gh-release@v2
-        with:
-          files: './*'
 
       - name: Setup Mamba
         uses: conda-incubator/setup-miniconda@v3
@@ -50,7 +45,7 @@ jobs:
           auto-update-conda: true
           python-version: "3.10"
           mamba-version: "*"
-          channels: conda-forge, nodefaults 
+          channels: conda-forge, nodefaults
           activate-environment: package-build
 
       - name: Build conda package
@@ -68,3 +63,6 @@ jobs:
         run: |
           conda activate package-build
           anaconda upload --user warpem $(conda build --output conda-recipe -c nvidia/label/cuda-11.8.0 -c pytorch -c conda-forge)
+
+      - name: Release the source on GitHub
+        uses: softprops/action-gh-release@v2

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python=3.11.9
     - libtiff
     - pytorch-cuda=11.8
-    - pytorch::pytorch=2.0.1
+    - pytorch::pytorch=2.0.1=py3.11_cuda11.8*
     - torchvision
     - fftw
     - cxx-compiler=1.3
@@ -34,7 +34,7 @@ requirements:
     - python=3.11.9
     - libtiff
     - pytorch-cuda=11.8
-    - pytorch::pytorch=2.0.1
+    - pytorch::pytorch=2.0.1=py3.11_cuda11.8*
     - torchvision
     - fftw
     - cxx-compiler=1.3

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python=3.11.9
     - libtiff
     - pytorch-cuda=11.8
-    - pytorch::pytorch=2.0.1=py3.11_cuda11.8*
+    - pytorch::pytorch=2.0.1=py3.11_cuda11.8_cudnn8.7.0_0
     - torchvision
     - fftw
     - cxx-compiler=1.3
@@ -34,7 +34,7 @@ requirements:
     - python=3.11.9
     - libtiff
     - pytorch-cuda=11.8
-    - pytorch::pytorch=2.0.1=py3.11_cuda11.8*
+    - pytorch::pytorch=2.0.1=py3.11_cuda11.8_cudnn8.7.0_0
     - torchvision
     - fftw
     - cxx-compiler=1.3


### PR DESCRIPTION
No release should be pushed if the conda build doesn't succeed now - this should also fix the broken conda build