### PR TITLE
add noiseScale parameter to TiltSeries.EraseDirt() and set to 100% during tomogram reconstruction

### DIFF
--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -2944,7 +2944,7 @@ namespace Warp
             {
                 for (int idata = 0; idata < TiltDataPreprocess.Length; idata++)
                 {
-                    EraseDirt(TiltDataPreprocess[idata][z], TiltMasks[z]);
+                    EraseDirt(TiltDataPreprocess[idata][z], TiltMasks[z], noiseScale: 1.0f);
                     if (idata == TiltDataPreprocess.Length - 1)
                         TiltMasks[z]?.FreeDevice();
 
@@ -10705,7 +10705,7 @@ namespace Warp
 
         static int[][] DirtErasureLabelsBuffer = new int[GPU.GetDeviceCount()][];
         static Image[] DirtErasureMaskBuffer = new Image[GPU.GetDeviceCount()];
-        public static void EraseDirt(Image tiltImage, Image tiltMask, float noiseScale = 1.0f)
+        public static void EraseDirt(Image tiltImage, Image tiltMask, float noiseScale = 0.1f)
         {
             if (tiltMask == null)
                 return;

--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -10705,7 +10705,7 @@ namespace Warp
 
         static int[][] DirtErasureLabelsBuffer = new int[GPU.GetDeviceCount()][];
         static Image[] DirtErasureMaskBuffer = new Image[GPU.GetDeviceCount()];
-        public static void EraseDirt(Image tiltImage, Image tiltMask)
+        public static void EraseDirt(Image tiltImage, Image tiltMask, float noiseScale = 1.0f)
         {
             if (tiltMask == null)
                 return;
@@ -10753,12 +10753,14 @@ namespace Warp
 
                 float[] NeighborhoodIntensities = Helper.IndexedSubset(ImageData, component.NeighborhoodIndices);
                 float2 MeanStd = MathHelper.MeanAndStd(NeighborhoodIntensities);
+                float ComponentMean = MeanStd.X;
+                float ComponentStd = MeanStd.Y; 
 
                 foreach (int id in component.ComponentIndices)
-                    ImageData[id] = RandN.NextSingle(MeanStd.X, MeanStd.Y * 0.1f);
+                    ImageData[id] = RandN.NextSingle(ComponentMean, ComponentStd * noiseScale);
 
                 foreach (int id in component.NeighborhoodIndices)
-                    ImageData[id] = MathHelper.Lerp(ImageData[id], RandN.NextSingle(MeanStd.X, MeanStd.Y * 0.1f), MaskSmoothData[id]);
+                    ImageData[id] = MathHelper.Lerp(ImageData[id], RandN.NextSingle(ComponentMean, ComponentStd * noiseScale), MaskSmoothData[id]);
             }
         }
 


### PR DESCRIPTION
c.f. #197 

@dtegunov I've exposed this as a parameter in the method which now defaults to 100% everywhere. In #197 you suggested to expose this as a parameter, did you mean as a parameter for tomogram reconstruction or something else?

@bbarad if you build from this branch you should be able to test whether this gives you similar performance to fidder/old warp