### PR TITLE
Make requirement for 'fully covered voxels' less strict in template matching

### DIFF
--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -2636,7 +2636,10 @@ namespace Warp
 
                     float WidthNoMargin = ImageDimensionsPhysical.X - BinnedAngPix - Margin;
                     float HeightNoMargin = ImageDimensionsPhysical.Y - BinnedAngPix - Margin;
-
+                    
+                    // Define threshold for valid tilts (80%)
+                    int minValidTilts = (int)(NTilts * 0.8f);
+                    
                     for ( int z = 0; z < DimsUndersampled.Z; z++)
                     {
                         float ZCoord = (z + 0.5f) * Undersample * BinnedAngPix;
@@ -2647,6 +2650,8 @@ namespace Warp
 
                         for (int p = 0; p < VolumePositions.Length; p++)
                         {
+                            int validTiltCount = 0;
+                            
                             for (int t = 0; t < NTilts; t++)
                             {
                                 int i = p * NTilts + t;
@@ -2656,9 +2661,13 @@ namespace Warp
                                     ImagePositions[i].X > WidthNoMargin ||
                                     ImagePositions[i].Y > HeightNoMargin))
                                 {
-                                    OccupancyMask[z][p] = 0;
-                                    break;
+                                    validTiltCount++;
                                 }
+                            }
+
+                            if (validTiltCount < minValidTilts)
+                            {
+                                OccupancyMask[z][p] = 0;
                             }
                         }
                     }

--- a/WarpLib/TiltSeries.cs
+++ b/WarpLib/TiltSeries.cs
@@ -2638,7 +2638,8 @@ namespace Warp
                     float HeightNoMargin = ImageDimensionsPhysical.Y - BinnedAngPix - Margin;
                     
                     // Define threshold for valid tilts (80%)
-                    int minValidTilts = (int)(NTilts * 0.8f);
+                    int NUsedTilts = UseTilt.Sum(b => b ? 1 : 0);
+                    int minValidTilts = (int)(NUsedTilts * 0.8f);
                     
                     for ( int z = 0; z < DimsUndersampled.Z; z++)
                     {
@@ -2657,9 +2658,11 @@ namespace Warp
                                 int i = p * NTilts + t;
 
                                 if (UseTilt[t] &&
-                                    (ImagePositions[i].X < Margin || ImagePositions[i].Y < Margin ||
-                                    ImagePositions[i].X > WidthNoMargin ||
-                                    ImagePositions[i].Y > HeightNoMargin))
+                                    (ImagePositions[i].X >= Margin || 
+                                     ImagePositions[i].Y >= Margin ||
+                                     ImagePositions[i].X <= WidthNoMargin ||
+                                     ImagePositions[i].Y <= HeightNoMargin)
+                                    )
                                 {
                                     validTiltCount++;
                                 }


### PR DESCRIPTION
dropped to a hardcoded 80% of tilts covered required for 'fully covered'

closes #193 - tests running now will merge unless issues come up