### PR TITLE
Use safe version of Helper.ToBytes when calculating data hashes in Species.cs

### DIFF
--- a/WarpLib/Sociology/Species.cs
+++ b/WarpLib/Sociology/Species.cs
@@ -2341,9 +2341,9 @@ namespace Warp.Sociology
             Builder.Append(MathHelper.GetSHA1(Helper.ToBytes(Helper.ToInterleaved(Helper.Combine(DescendantParticles.Select(p => p.Coordinates))))));
             Builder.Append(MathHelper.GetSHA1(Helper.ToBytes(Helper.ToInterleaved(Helper.Combine(DescendantParticles.Select(p => p.Angles))))));
 
-            Builder.Append(MathHelper.GetSHA1(Helper.ToBytes(HalfMap1.GetHostContinuousCopy())));
-            Builder.Append(MathHelper.GetSHA1(Helper.ToBytes(HalfMap2.GetHostContinuousCopy())));
-            Builder.Append(MathHelper.GetSHA1(Helper.ToBytes(Mask.GetHostContinuousCopy())));
+            Builder.Append(MathHelper.GetSHA1(Helper.ToBytesSafe(HalfMap1.GetHostContinuousCopy())));
+            Builder.Append(MathHelper.GetSHA1(Helper.ToBytesSafe(HalfMap2.GetHostContinuousCopy())));
+            Builder.Append(MathHelper.GetSHA1(Helper.ToBytesSafe(Mask.GetHostContinuousCopy())));
 
             Version = MathHelper.GetSHA1(Helper.ToBytes(Builder.ToString().ToCharArray())).Substring(0, 8);
         }

--- a/WarpLib/Tools/Helper.cs
+++ b/WarpLib/Tools/Helper.cs
@@ -1106,6 +1106,15 @@ namespace Warp.Tools
 
             return Bytes;
         }
+        
+        public static byte[] ToBytesSafe(float[] data)
+        {
+            // truncates data in byte array if necessary
+            byte[] Bytes = new byte[Math.Min(1 << 19, data.Length * sizeof(float))];
+            Buffer.BlockCopy(data, 0, Bytes, 0, Bytes.Length);
+
+            return Bytes;
+        }
 
         public static byte[] ToBytes(int[] data)
         {


### PR DESCRIPTION
closes #270 

this should maintain identical behavior to what was there before and also work for large boxes

cc @deadlift385