### PR TITLE
Fix DFT sample frequency calculation in PS1D and CTF peak/zero crossing finding methods

### DIFF
--- a/WarpLib/CTF.cs
+++ b/WarpLib/CTF.cs
@@ -731,7 +731,7 @@ namespace Warp
 
             for (int i = 0; i < dValues.Length - 1; i++)
                 if (Math.Sign(dValues[i]) > 0 && Math.Sign(dValues[i + 1]) < 0)
-                    Result.Add(0.5f * i / Values.Length);
+                    Result.Add(0.5f * i / (Values.Length - 1));
 
             return Result.ToArray();
         }
@@ -745,7 +745,7 @@ namespace Warp
 
             for (int i = 0; i < dValues.Length - 1; i++)
                 if (Math.Sign(dValues[i]) < 0 && Math.Sign(dValues[i + 1]) > 0)
-                    Result.Add(0.5f * i / Values.Length);
+                    Result.Add(0.5f * i / (Values.Length - 1));
 
             return Result.ToArray();
         }

--- a/WarpLib/Movie.cs
+++ b/WarpLib/Movie.cs
@@ -1495,7 +1495,7 @@ namespace Warp
                 float[] CTFAverage1DData = CTFAverage1D.GetHost(Intent.Read)[0];
                 float2[] ForPS1D = new float2[DimsRegion.X / 2];
                 for (int i = 0; i < ForPS1D.Length; i++)
-                    ForPS1D[i] = new float2((float)i / DimsRegion.X, (float)Math.Round(CTFAverage1DData[i], 4));
+                    ForPS1D[i] = new float2(0.5f * (float)i / (PS1D.Length - 1), (float)Math.Round(CTFAverage1DData[i], 4));
                 _PS1D = ForPS1D;
 
                 CTFAverage1D.Dispose();
@@ -1552,10 +1552,10 @@ namespace Warp
                 float2[] ForPS1D = new float2[PS1D.Length];
                 if (keepbackground)
                     for (int i = 0; i < ForPS1D.Length; i++)
-                        ForPS1D[i] = new float2((float)i / DimsRegion.X, RotationalAverageData[i] + _SimulatedBackground.Interp((float)i / DimsRegion.X));
+                        ForPS1D[i] = new float2(0.5f * (float)i / ForPS1D.Length, RotationalAverageData[i] + _SimulatedBackground.Interp(0.5f * (float)i / ForPS1D.Length));
                 else
                     for (int i = 0; i < ForPS1D.Length; i++)
-                        ForPS1D[i] = new float2((float)i / DimsRegion.X, RotationalAverageData[i]);
+                        ForPS1D[i] = new float2(0.5f * (float)i / ForPS1D.Length, RotationalAverageData[i]);
                 MathHelper.UnNaN(ForPS1D);
 
                 _PS1D = ForPS1D;


### PR DESCRIPTION
closes #302 