### PR TITLE
Revert "Fix DFT sample frequency calculation in PS1D and CTF peak/zero crossing finding methods"

### DIFF
--- a/WarpLib/CTF.cs
+++ b/WarpLib/CTF.cs
@@ -731,7 +731,7 @@ namespace Warp
 
             for (int i = 0; i < dValues.Length - 1; i++)
                 if (Math.Sign(dValues[i]) > 0 && Math.Sign(dValues[i + 1]) < 0)
-                    Result.Add(0.5f * i / (Values.Length - 1));
+                    Result.Add(0.5f * i / Values.Length);
 
             return Result.ToArray();
         }
@@ -745,7 +745,7 @@ namespace Warp
 
             for (int i = 0; i < dValues.Length - 1; i++)
                 if (Math.Sign(dValues[i]) < 0 && Math.Sign(dValues[i + 1]) > 0)
-                    Result.Add(0.5f * i / (Values.Length - 1));
+                    Result.Add(0.5f * i / Values.Length);
 
             return Result.ToArray();
         }

--- a/WarpLib/Movie.cs
+++ b/WarpLib/Movie.cs
@@ -1498,7 +1498,7 @@ namespace Warp
                 float[] CTFAverage1DData = CTFAverage1D.GetHost(Intent.Read)[0];
                 float2[] ForPS1D = new float2[DimsRegion.X / 2];
                 for (int i = 0; i < ForPS1D.Length; i++)
-                    ForPS1D[i] = new float2(0.5f * (float)i / (PS1D.Length - 1), (float)Math.Round(CTFAverage1DData[i], 4));
+                    ForPS1D[i] = new float2((float)i / DimsRegion.X, (float)Math.Round(CTFAverage1DData[i], 4));
                 _PS1D = ForPS1D;
 
                 CTFAverage1D.Dispose();
@@ -1555,10 +1555,10 @@ namespace Warp
                 float2[] ForPS1D = new float2[PS1D.Length];
                 if (keepbackground)
                     for (int i = 0; i < ForPS1D.Length; i++)
-                        ForPS1D[i] = new float2(0.5f * (float)i / ForPS1D.Length, RotationalAverageData[i] + _SimulatedBackground.Interp(0.5f * (float)i / ForPS1D.Length));
+                        ForPS1D[i] = new float2((float)i / DimsRegion.X, RotationalAverageData[i] + _SimulatedBackground.Interp((float)i / DimsRegion.X));
                 else
                     for (int i = 0; i < ForPS1D.Length; i++)
-                        ForPS1D[i] = new float2(0.5f * (float)i / ForPS1D.Length, RotationalAverageData[i]);
+                        ForPS1D[i] = new float2((float)i / DimsRegion.X, RotationalAverageData[i]);
                 MathHelper.UnNaN(ForPS1D);
 
                 _PS1D = ForPS1D;


### PR DESCRIPTION
Reverts warpem/warp#303

c.f. https://github.com/warpem/warp/commit/712c02e0579816fc8575371238da4b27fb0845c9#commitcomment-149922935