### PR TITLE
increase WarpWorker request max body size to 100MB

### DIFF
--- a/WarpWorker/WarpWorker.cs
+++ b/WarpWorker/WarpWorker.cs
@@ -71,9 +71,13 @@ namespace WarpWorker
 
             var Host = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder().ConfigureWebHostDefaults(webBuilder =>
             {
-                webBuilder.UseKestrel(options => options.ListenAnyIP(Port))
-                          .UseStartup<RESTStartup>()
-                          .ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Warning));
+                webBuilder.UseKestrel(options =>
+                    {
+                        options.ListenAnyIP(Port);
+                        options.Limits.MaxRequestBodySize = 104857600; // 100 MB
+                    })
+                    .UseStartup<RESTStartup>()
+                    .ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Warning));
             }).Build();
             Host.Start();
 


### PR DESCRIPTION
closes #315 

this is not a great solution for when we actually run distributed workloads as requests are more likely to timeout/be interrupted