### PR TITLE
Fixes particleseries export when user requests a single tilt for export

### DIFF
--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -929,23 +929,18 @@ namespace WarpTools.Commands
             List<int> UsedTilts = exportOptions.DoLimitDose
                 ? tiltSeries.IndicesSortedDose.Take(exportOptions.NTilts).ToList()
                 : tiltSeries.IndicesSortedDose.ToList();
+
             float TiltDose;
-            if (UsedTilts.Count == 0) {
-                // No tilts available, use a default value
-                TiltDose = 1.0f; // Default exposure value
-                Console.WriteLine($"Warning: No tilts available for {tiltSeries.Name}, using default dose");
-            } else if (UsedTilts.Count > 1) {
-                // Normal case - calculate dose difference between first two tilts
+            if (UsedTilts.Count <= 1)
+            {
+                // For single tilt, use the absolute dose value instead of a difference
+                TiltDose = UsedTilts.Count == 1 ? tiltSeries.Dose[UsedTilts[0]] : 1.0f;
+                Console.WriteLine($"Using single tilt dose: {TiltDose}");
+            }
+            else
+            {
+                // Normal case - calculate dose difference between tilts
                 TiltDose = tiltSeries.Dose[UsedTilts[1]] - tiltSeries.Dose[UsedTilts[0]];
-            } else {
-                // Single tilt case
-                if (tiltSeries.Dose.Length > UsedTilts[0]) {
-                    TiltDose = tiltSeries.Dose[UsedTilts[0]]; 
-                } else {
-                    // Safety check if Dose array doesn't contain this index
-                    TiltDose = 1.0f;
-                    Console.WriteLine($"Warning: Dose information missing for tilt {UsedTilts[0]} in {tiltSeries.Name}");
-                }
             }
             UsedTilts.Sort();
 

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -926,36 +926,16 @@ namespace WarpTools.Commands
                 "rlnTomoImportFractionalDose"
             });
 
-            List<int> UsedTilts = new List<int>();
-            if (exportOptions.DoLimitDose && tiltSeries.IndicesSortedDose != null && tiltSeries.IndicesSortedDose.Length > 0)
-            {
-                UsedTilts = tiltSeries.IndicesSortedDose.Take(Math.Min(exportOptions.NTilts, tiltSeries.IndicesSortedDose.Length)).ToList();
-            }
-            else if (tiltSeries.IndicesSortedDose != null && tiltSeries.IndicesSortedDose.Length > 0)
-            {
-                UsedTilts = tiltSeries.IndicesSortedDose.ToList();
-            }
-            else
-            {
-                // Fallback in case IndicesSortedDose is null or empty
-                Console.WriteLine($"Warning: No tilt indices available for {tiltSeries.Name}");
-                // Add at least one index if dose array isn't empty
-                if (tiltSeries.Dose != null && tiltSeries.Dose.Length > 0)
-                    UsedTilts.Add(0);
-            }
-
-// Debug information
-            Console.WriteLine($"DEBUG: UsedTilts.Count = {UsedTilts.Count}");
-            if (UsedTilts.Count > 0)
-                Console.WriteLine($"DEBUG: First tilt index = {UsedTilts[0]}");
-
-            float TiltDose = 1.0f; // Default value
-            if (UsedTilts.Count > 0 && tiltSeries.Dose != null && UsedTilts[0] < tiltSeries.Dose.Length)
-            {
-                if (UsedTilts.Count > 1 && UsedTilts[1] < tiltSeries.Dose.Length)
-                    TiltDose = tiltSeries.Dose[UsedTilts[1]] - tiltSeries.Dose[UsedTilts[0]];
-                else
-                    TiltDose = tiltSeries.Dose[UsedTilts[0]];
+            List<int> UsedTilts = exportOptions.DoLimitDose
+                ? tiltSeries.IndicesSortedDose.Take(exportOptions.NTilts).ToList()
+                : tiltSeries.IndicesSortedDose.ToList();
+            float TiltDose;
+            if (UsedTilts.Count > 1) {
+                // Normal case - calculate dose difference between first two tilts
+                TiltDose = tiltSeries.Dose[UsedTilts[1]] - tiltSeries.Dose[UsedTilts[0]];
+            } else {
+                // Single tilt case - use a default value or the dose of the single tilt
+                TiltDose = tiltSeries.Dose[UsedTilts[0]]; // Or another appropriate value
             }
             UsedTilts.Sort();
 

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -929,8 +929,14 @@ namespace WarpTools.Commands
             List<int> UsedTilts = exportOptions.DoLimitDose
                 ? tiltSeries.IndicesSortedDose.Take(exportOptions.NTilts).ToList()
                 : tiltSeries.IndicesSortedDose.ToList();
-            float TiltDose =
-                tiltSeries.Dose[UsedTilts[1]] - tiltSeries.Dose[UsedTilts[0]];
+            float TiltDose;
+            if (UsedTilts.Count > 1) {
+                // Normal case - calculate dose difference between first two tilts
+                TiltDose = tiltSeries.Dose[UsedTilts[1]] - tiltSeries.Dose[UsedTilts[0]];
+            } else {
+                // Single tilt case - use a default value or the dose of the single tilt
+                TiltDose = tiltSeries.Dose[UsedTilts[0]]; // Or another appropriate value
+            }
             UsedTilts.Sort();
 
             tiltSeries.VolumeDimensionsPhysical = exportOptions.DimensionsPhysical;

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -930,12 +930,22 @@ namespace WarpTools.Commands
                 ? tiltSeries.IndicesSortedDose.Take(exportOptions.NTilts).ToList()
                 : tiltSeries.IndicesSortedDose.ToList();
             float TiltDose;
-            if (UsedTilts.Count > 1) {
+            if (UsedTilts.Count == 0) {
+                // No tilts available, use a default value
+                TiltDose = 1.0f; // Default exposure value
+                Console.WriteLine($"Warning: No tilts available for {tiltSeries.Name}, using default dose");
+            } else if (UsedTilts.Count > 1) {
                 // Normal case - calculate dose difference between first two tilts
                 TiltDose = tiltSeries.Dose[UsedTilts[1]] - tiltSeries.Dose[UsedTilts[0]];
             } else {
-                // Single tilt case - use a default value or the dose of the single tilt
-                TiltDose = tiltSeries.Dose[UsedTilts[0]]; // Or another appropriate value
+                // Single tilt case
+                if (tiltSeries.Dose.Length > UsedTilts[0]) {
+                    TiltDose = tiltSeries.Dose[UsedTilts[0]]; 
+                } else {
+                    // Safety check if Dose array doesn't contain this index
+                    TiltDose = 1.0f;
+                    Console.WriteLine($"Warning: Dose information missing for tilt {UsedTilts[0]} in {tiltSeries.Name}");
+                }
             }
             UsedTilts.Sort();
 

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -937,6 +937,7 @@ namespace WarpTools.Commands
                 // Single tilt case - use a default value or the dose of the single tilt
                 TiltDose = tiltSeries.Dose[UsedTilts[0]]; // Or another appropriate value
             }
+            
             UsedTilts.Sort();
 
             tiltSeries.VolumeDimensionsPhysical = exportOptions.DimensionsPhysical;


### PR DESCRIPTION
I tested my fix and can confrim that particle export works
```
WarpTools ts_export_particles --settings tiltseries.settings --box 180 --output_angpix 1 --input_star m_run3/species/test_b0f696d1/particles_2relion.star  --coords_angpix 1 --diameter 130 --2d --relative_output_paths --output_star 1tilt/particles.star --n_tilts 1 --max_missing_tilts 1 --input_data tomostar/gs04_ts_003.tomostar
Running command ts_export_particles with:
input_star = m_run3/species/test_b0f696d1/particles_2relion.star
input_directory = null
input_pattern = *.star
coords_angpix = 1
normalized_coords = False
output_star = 1tilt/particles.star
output_angpix = 1
box = 180
diameter = 130
relative_output_paths = True
2d = True
3d = False
dont_normalize_input = False
dont_normalize_3d = False
n_tilts = 1
max_missing_tilts = 1
device_list = {  }
perdevice = 1
workers = {  }
settings = tiltseries.settings
input_data = { tomostar/gs04_ts_003.tomostar }
input_data_recursive = False
input_processing = null
output_processing = null
input_norawdata = False
strict = False

Using alternative input specified by --input_data
File search will be relative to /home/pranav/Desktop/pranav/data/training/test/
1 files found
Parsing previous results for each item, if available...
1/1, previous metadata found for 1
Found 42931 particles in 41 tilt series
Connecting to workers...
Connected to 1 workers
1/1, 00:00 remaining
Finished processing in 00:00:07
Saying goodbye to all workers... Done
```
Output from `particles.star`
```
data_general

_rlnTomoSubTomosAre2DStacks   1




data_optics

loop_
_rlnOpticsGroup #1
_rlnOpticsGroupName #2
_rlnSphericalAberration #3
_rlnVoltage #4
_rlnTomoTiltSeriesPixelSize #5
_rlnCtfDataAreCtfPremultiplied #6
_rlnImageDimensionality #7
_rlnTomoSubtomogramBinning #8
_rlnImagePixelSize #9
_rlnImageSize #10
_rlnAmplitudeContrast #11
  1  opticsGroup1  2.700  300.000  0.73030  1  2  1.36930  1.00000  180  0.100




data_particles

loop_
_rlnTomoName #1
_rlnTomoParticleId #2
_rlnCoordinateX #3
_rlnCoordinateY #4
_rlnCoordinateZ #5
_rlnAngleRot #6
_rlnAngleTilt #7
_rlnAnglePsi #8
_rlnTomoParticleName #9
_rlnOpticsGroup #10
_rlnImageName #11
_rlnOriginXAngst #12
_rlnOriginYAngst #13
_rlnOriginZAngst #14
_rlnTomoVisibleFrames #15
  gs04_ts_003.tomostar    1  2343.632  2677.504   586.176  133.036   64.752  -109.393    gs04_ts_003/1  1  ../tiltseries/particleseries/gs04_ts_003/gs04_ts_003_1.00A_000001.mrcs  0.0  0.0  0.0  [1]
  gs04_ts_003.tomostar    2   799.198  1223.046  1254.907   83.831   42.335  -102.157    gs04_ts_003/2  1  ../tiltseries/particleseries/gs04_ts_003/gs04_ts_003_1.00A_000002.mrcs  0.0  0.0  0.0  [1]
  gs04_ts_003.tomostar    3  1158.280  2451.366  1284.970   72.484   43.560    -7.668    gs04_ts_003/3  1  ../tiltseries/particleseries/gs04_ts_003/gs04_ts_003_1.00A_000003.mrcs  0.0  0.0  0.0  [1]
  gs04_ts_003.tomostar    4  2759.882   483.883   489.617  138.853   45.280   -24.866    gs04_ts_003/4  1  ../tiltseries/particleseries/gs04_ts_003/gs04_ts_003_1.00A_000004.mrcs  0.0  0.0  0.0  [1]
  gs04_ts_003.tomostar    5   439.446   385.190   290.779   92.212   43.750    20.844    gs04_ts_003/5  1  ../tiltseries/particleseries/gs04_ts_003/gs04_ts_003_1.00A_000005.mrcs  0.0  0.0  0.0  [1]
  ```