### PR TITLE
explicitly set lower degree of parallelism when computing species hash 

### DIFF
--- a/WarpLib/Sociology/DataSource.cs
+++ b/WarpLib/Sociology/DataSource.cs
@@ -358,12 +358,14 @@ namespace Warp.Sociology
 
             string[] Paths = Files.Values.ToArray();
             string[] Hashes = new string[Paths.Length];
-            Parallel.For(0, Paths.Length, (i) =>
-            {
-                var file = Paths[i];
-                Movie Movie = IsTiltSeries ? new TiltSeries(FolderPath + file) : new Movie(FolderPath + file);
-                Hashes[i] = Movie.GetProcessingHash();
-            });
+            Parallel.For(0, Paths.Length,
+                new ParallelOptions { MaxDegreeOfParallelism = Math.Min(20, Environment.ProcessorCount) },
+                i =>
+                {
+                    var file = Paths[i];
+                    Movie Movie = IsTiltSeries ? new TiltSeries(FolderPath + file) : new Movie(FolderPath + file);
+                    Hashes[i] = Movie.GetProcessingHash();
+                });
 
             Builder.AppendJoin("", Hashes);
 


### PR DESCRIPTION
closes #394  - thank you @cai-cryo for raising the issue and providing your solution!

This PR only changes behavior in environments with large numbers of CPUs