### PR TITLE
Preserve star fields

### DIFF
--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -181,11 +181,21 @@ namespace WarpTools.Commands
                     Console.WriteLine($"TS: {kvp.Key}   Particles: {kvp.Value.Count}");
 
             float3[] xyz = GetCoordinates(inputStar);
+
+            //<-- START OF PATCH -->
+            // Check for the existence of Euler angle columns directly instead of checking for non-zero values.
+            // This correctly handles cases where particles have a legitimate (0,0,0) orientation.
+            bool inputHasEulerAngles = inputStar.HasColumn("rlnAngleRot") &&
+                                       inputStar.HasColumn("rlnAngleTilt") &&
+                                       inputStar.HasColumn("rlnAnglePsi");
+
+            // GetEulerAngles is already designed to return zeroed vectors if columns are missing.
             float3[] rotTiltPsi = GetEulerAngles(inputStar); // degrees
-            bool inputHasEulerAngles = rotTiltPsi.All(v => !v.EqualsZero());
 
             if (Helper.IsDebug)
                 Console.WriteLine($"input has euler angles?: {inputHasEulerAngles}");
+            //<-- END OF PATCH -->
+
             Console.WriteLine(
                 $"Found {xyz.Count()} particles in {tiltSeriesIdToParticleIndices.Count()} tilt series");
 

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -929,23 +929,18 @@ namespace WarpTools.Commands
             List<int> UsedTilts = exportOptions.DoLimitDose
                 ? tiltSeries.IndicesSortedDose.Take(exportOptions.NTilts).ToList()
                 : tiltSeries.IndicesSortedDose.ToList();
+
             float TiltDose;
-            if (UsedTilts.Count == 0) {
-                // No tilts available, use a default value
-                TiltDose = 1.0f; // Default exposure value
-                Console.WriteLine($"Warning: No tilts available for {tiltSeries.Name}, using default dose");
-            } else if (UsedTilts.Count > 1) {
-                // Normal case - calculate dose difference between first two tilts
+            if (UsedTilts.Count <= 1)
+            {
+                // For single tilt, use the absolute dose value instead of a difference
+                TiltDose = UsedTilts.Count == 1 ? tiltSeries.Dose[UsedTilts[0]] : 1.0f;
+                Console.WriteLine($"Using single tilt dose: {TiltDose}");
+            }
+            else
+            {
+                // Normal case - calculate dose difference between tilts
                 TiltDose = tiltSeries.Dose[UsedTilts[1]] - tiltSeries.Dose[UsedTilts[0]];
-            } else {
-                // Single tilt case
-                if (tiltSeries.Dose.Length > UsedTilts[0]) {
-                    TiltDose = tiltSeries.Dose[UsedTilts[0]]; 
-                } else {
-                    // Safety check if Dose array doesn't contain this index
-                    TiltDose = 1.0f;
-                    Console.WriteLine($"Warning: Dose information missing for tilt {UsedTilts[0]} in {tiltSeries.Name}");
-                }
             }
             UsedTilts.Sort();
 

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -926,36 +926,16 @@ namespace WarpTools.Commands
                 "rlnTomoImportFractionalDose"
             });
 
-            List<int> UsedTilts = new List<int>();
-            if (exportOptions.DoLimitDose && tiltSeries.IndicesSortedDose != null && tiltSeries.IndicesSortedDose.Length > 0)
-            {
-                UsedTilts = tiltSeries.IndicesSortedDose.Take(Math.Min(exportOptions.NTilts, tiltSeries.IndicesSortedDose.Length)).ToList();
-            }
-            else if (tiltSeries.IndicesSortedDose != null && tiltSeries.IndicesSortedDose.Length > 0)
-            {
-                UsedTilts = tiltSeries.IndicesSortedDose.ToList();
-            }
-            else
-            {
-                // Fallback in case IndicesSortedDose is null or empty
-                Console.WriteLine($"Warning: No tilt indices available for {tiltSeries.Name}");
-                // Add at least one index if dose array isn't empty
-                if (tiltSeries.Dose != null && tiltSeries.Dose.Length > 0)
-                    UsedTilts.Add(0);
-            }
-
-// Debug information
-            Console.WriteLine($"DEBUG: UsedTilts.Count = {UsedTilts.Count}");
-            if (UsedTilts.Count > 0)
-                Console.WriteLine($"DEBUG: First tilt index = {UsedTilts[0]}");
-
-            float TiltDose = 1.0f; // Default value
-            if (UsedTilts.Count > 0 && tiltSeries.Dose != null && UsedTilts[0] < tiltSeries.Dose.Length)
-            {
-                if (UsedTilts.Count > 1 && UsedTilts[1] < tiltSeries.Dose.Length)
-                    TiltDose = tiltSeries.Dose[UsedTilts[1]] - tiltSeries.Dose[UsedTilts[0]];
-                else
-                    TiltDose = tiltSeries.Dose[UsedTilts[0]];
+            List<int> UsedTilts = exportOptions.DoLimitDose
+                ? tiltSeries.IndicesSortedDose.Take(exportOptions.NTilts).ToList()
+                : tiltSeries.IndicesSortedDose.ToList();
+            float TiltDose;
+            if (UsedTilts.Count > 1) {
+                // Normal case - calculate dose difference between first two tilts
+                TiltDose = tiltSeries.Dose[UsedTilts[1]] - tiltSeries.Dose[UsedTilts[0]];
+            } else {
+                // Single tilt case - use a default value or the dose of the single tilt
+                TiltDose = tiltSeries.Dose[UsedTilts[0]]; // Or another appropriate value
             }
             UsedTilts.Sort();
 

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -929,8 +929,14 @@ namespace WarpTools.Commands
             List<int> UsedTilts = exportOptions.DoLimitDose
                 ? tiltSeries.IndicesSortedDose.Take(exportOptions.NTilts).ToList()
                 : tiltSeries.IndicesSortedDose.ToList();
-            float TiltDose =
-                tiltSeries.Dose[UsedTilts[1]] - tiltSeries.Dose[UsedTilts[0]];
+            float TiltDose;
+            if (UsedTilts.Count > 1) {
+                // Normal case - calculate dose difference between first two tilts
+                TiltDose = tiltSeries.Dose[UsedTilts[1]] - tiltSeries.Dose[UsedTilts[0]];
+            } else {
+                // Single tilt case - use a default value or the dose of the single tilt
+                TiltDose = tiltSeries.Dose[UsedTilts[0]]; // Or another appropriate value
+            }
             UsedTilts.Sort();
 
             tiltSeries.VolumeDimensionsPhysical = exportOptions.DimensionsPhysical;

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -930,12 +930,22 @@ namespace WarpTools.Commands
                 ? tiltSeries.IndicesSortedDose.Take(exportOptions.NTilts).ToList()
                 : tiltSeries.IndicesSortedDose.ToList();
             float TiltDose;
-            if (UsedTilts.Count > 1) {
+            if (UsedTilts.Count == 0) {
+                // No tilts available, use a default value
+                TiltDose = 1.0f; // Default exposure value
+                Console.WriteLine($"Warning: No tilts available for {tiltSeries.Name}, using default dose");
+            } else if (UsedTilts.Count > 1) {
                 // Normal case - calculate dose difference between first two tilts
                 TiltDose = tiltSeries.Dose[UsedTilts[1]] - tiltSeries.Dose[UsedTilts[0]];
             } else {
-                // Single tilt case - use a default value or the dose of the single tilt
-                TiltDose = tiltSeries.Dose[UsedTilts[0]]; // Or another appropriate value
+                // Single tilt case
+                if (tiltSeries.Dose.Length > UsedTilts[0]) {
+                    TiltDose = tiltSeries.Dose[UsedTilts[0]]; 
+                } else {
+                    // Safety check if Dose array doesn't contain this index
+                    TiltDose = 1.0f;
+                    Console.WriteLine($"Warning: Dose information missing for tilt {UsedTilts[0]} in {tiltSeries.Name}");
+                }
             }
             UsedTilts.Sort();
 

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -937,6 +937,7 @@ namespace WarpTools.Commands
                 // Single tilt case - use a default value or the dose of the single tilt
                 TiltDose = tiltSeries.Dose[UsedTilts[0]]; // Or another appropriate value
             }
+            
             UsedTilts.Sort();
 
             tiltSeries.VolumeDimensionsPhysical = exportOptions.DimensionsPhysical;


### PR DESCRIPTION
following TM in an external package,  ts_export_particles ignore the entire Rot,Tilt,Psi columns in the star table if any one of the angles was 0. This patch relaxes that requirement and the program now preserves these columns in the final start file after particle export.