### PR TITLE
added options to export ctf parameters as csv and subtomogram without ctf correction

### DIFF
--- a/WarpLib/Movie/Movie.cs
+++ b/WarpLib/Movie/Movie.cs
@@ -1674,14 +1674,14 @@ namespace Warp
 
         #region GetCTFs methods
 
-        public virtual Image GetCTFsForOneParticle(ProcessingOptionsBase options, float3 coords, Image ctfCoords, Image gammaCorrection, bool weighted = true, bool weightsonly = false, bool useglobalweights = false, Image result = null)
+        public virtual Image GetCTFsForOneParticle(ProcessingOptionsBase options, float3 coords, Image ctfCoords, Image gammaCorrection, bool weighted = true, bool weightsonly = false, bool useglobalweights = false, Image result = null, string outputpath = "")
         {
             float3[] PerFrameCoords = Helper.ArrayOfConstant(coords, NFrames);
 
-            return GetCTFsForOneParticle(options, PerFrameCoords, ctfCoords, gammaCorrection, weighted, weightsonly, useglobalweights, result);
+            return GetCTFsForOneParticle(options, PerFrameCoords, ctfCoords, gammaCorrection, weighted, weightsonly, useglobalweights, result, outputpath);
         }
 
-        public virtual Image GetCTFsForOneParticle(ProcessingOptionsBase options, float3[] coordsMoving, Image ctfCoords, Image gammaCorrection, bool weighted = true, bool weightsonly = false, bool useglobalweights = false, Image result = null)
+        public virtual Image GetCTFsForOneParticle(ProcessingOptionsBase options, float3[] coordsMoving, Image ctfCoords, Image gammaCorrection, bool weighted = true, bool weightsonly = false, bool useglobalweights = false, Image result = null, string outputpath = "")
         {
             float3[] ImagePositions = GetPositionInAllFrames(coordsMoving);
 

--- a/WarpLib/OptionsWarp.cs
+++ b/WarpLib/OptionsWarp.cs
@@ -680,6 +680,9 @@ namespace Warp
 
                 MakeSparse = Tasks.TomoSubReconstructMakeSparse,
 
+                OutputCTFCSV = Tasks.TomoSubReconstructCTFCSV,
+                CorrectCTF = Tasks.TomoSubReconstructCorrectCTF,
+
                 UseCPU = Tasks.UseCPU
             });
 
@@ -2079,6 +2082,22 @@ namespace Warp
         {
             get { return _TomoSubReconstructMakeSparse; }
             set { if (value != _TomoSubReconstructMakeSparse) { _TomoSubReconstructMakeSparse = value; OnPropertyChanged(); } }
+        }
+        
+        private bool _TomoSubReconstructCTFCSV = true;
+        [WarpSerializable]
+        public bool TomoSubReconstructCTFCSV
+        {
+            get { return _TomoSubReconstructCTFCSV; }
+            set { if (value != _TomoSubReconstructCTFCSV) { _TomoSubReconstructCTFCSV = value; OnPropertyChanged(); } }
+        }
+        
+        private bool _TomoSubReconstructCorrectCTF = true;
+        [WarpSerializable]
+        public bool TomoSubReconstructCorrectCTF
+        {
+            get { return _TomoSubReconstructCorrectCTF; }
+            set { if (value != _TomoSubReconstructCorrectCTF) { _TomoSubReconstructCorrectCTF = value; OnPropertyChanged(); } }
         }
 
         #endregion

--- a/WarpLib/TiltSeries/TiltSeries.cs
+++ b/WarpLib/TiltSeries/TiltSeries.cs
@@ -945,16 +945,16 @@ namespace Warp
 
         #region GetCTFs methods
 
-        public override Image GetCTFsForOneParticle(ProcessingOptionsBase options, float3 coords, Image ctfCoords, Image gammaCorrection, bool weighted = true, bool weightsonly = false, bool useglobalweights = false, Image result = null)
+        public override Image GetCTFsForOneParticle(ProcessingOptionsBase options, float3 coords, Image ctfCoords, Image gammaCorrection, bool weighted = true, bool weightsonly = false, bool useglobalweights = false, Image result = null, string outputpath = "")
         {
             float3[] PerTiltCoords = new float3[NTilts];
             for (int i = 0; i < NTilts; i++)
                 PerTiltCoords[i] = coords;
 
-            return GetCTFsForOneParticle(options, PerTiltCoords, ctfCoords, gammaCorrection, weighted, weightsonly, useglobalweights, result);
+            return GetCTFsForOneParticle(options, PerTiltCoords, ctfCoords, gammaCorrection, weighted, weightsonly, useglobalweights, result, outputpath);
         }
 
-        public override Image GetCTFsForOneParticle(ProcessingOptionsBase options, float3[] coordsMoving, Image ctfCoords, Image gammaCorrection, bool weighted = true, bool weightsonly = false, bool useglobalweights = false, Image result = null)
+        public override Image GetCTFsForOneParticle(ProcessingOptionsBase options, float3[] coordsMoving, Image ctfCoords, Image gammaCorrection, bool weighted = true, bool weightsonly = false, bool useglobalweights = false, Image result = null, string outputpath = "")
         {
             float3[] ImagePositions = GetPositionInAllTilts(coordsMoving);
 
@@ -1015,6 +1015,25 @@ namespace Warp
                 }
 
                 Params[t] = CurrCTF.ToStruct();
+            }
+
+            if (outputpath != "")
+            {
+                using (StreamWriter writer = new StreamWriter(outputpath))
+                {
+                    string output = string.Join(", ", typeof(CTFStruct)
+                                .GetFields()
+                                .Select(field => $"{field.Name}"));
+                    writer.WriteLine($"TiltAngle, X, Y, Z, {output}");
+
+                    for (int t = 0; t < NTilts; t++)
+                    {
+                        string output_t = string.Join(", ", typeof(CTFStruct)
+                                .GetFields()
+                                .Select(field => $"{field.GetValue(Params[t])}"));
+                        writer.WriteLine($"{Angles[t]}, {coordsMoving[t].X}, {coordsMoving[t].Y}, {coordsMoving[t].Z}, {output_t}");
+                    }
+                }
             }
 
             Image Result = result == null ? new Image(IntPtr.Zero, new int3(ctfCoords.Dims.X, ctfCoords.Dims.Y, NTilts), true) : result;

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -75,7 +75,7 @@ namespace WarpTools.Commands
 
         [Option("3d", HelpText = "Output particles as 3d images (subtomograms)")]
         public bool Output3DParticles { get; set; }
-
+        
         [OptionGroup("Expert options")]
         [Option("dont_normalize_input",
             HelpText =
@@ -86,6 +86,12 @@ namespace WarpTools.Commands
             HelpText =
                 "Don't normalize output particle volumes (only works with --3d)")]
         public bool DontNormalizeSubtomos { get; set; }
+
+        [Option("output_ctf_csv", HelpText = "Export CTF parameters as CSV files")]
+        public bool OutputCTFCSV { get; set; }
+
+        [Option("dont_correct_ctf_3d", HelpText = "Dont apply ctf correction to 3d subtomogram")]
+        public bool DontCorrectCTFSubtomos { get; set; }
 
         [Option("n_tilts",
             HelpText =
@@ -457,6 +463,8 @@ namespace WarpTools.Commands
             options.Tasks.Export2DBoxSize = cli.OutputBoxSize;
             options.Tasks.Export2DParticleDiameter = cli.OutputBoxSize;
             options.Tasks.InputNormalize = !cli.DontNormalizeInputImages;
+            options.Tasks.TomoSubReconstructCTFCSV = cli.OutputCTFCSV;
+            options.Tasks.TomoSubReconstructCorrectCTF = !cli.DontCorrectCTFSubtomos;
 
             options.Tasks.OutputNormalize =
                 cli.Output3DParticles && !cli.DontNormalizeSubtomos;


### PR DESCRIPTION
Dear WARP/M developer,
    I have implemented two new options to control the format of subtomograms exported by WARP. 
    The first option is ```--output_ctf_csv```, which will tell WARP to export ctf parameters for each subtomogram as a csv file. The name of csv file have the same prefix as the 3DCTF exported by WARP and is located at the same folder for the corresponding subtomogram. 
    The second option is ```--dont_correct_ctf_3d```, which will tell WARP to export subtomogram without CTF correction. I added a condition ```if (options.CorrectCTF)``` to toggle on 
```
ImagesFT[threadID].Multiply(CTFs[threadID]);
```
when the argument ```--dont_correct_ctf_3d``` is not enabled. In the backprojection step,
```
Projectors[threadID].BackProject(ImagesFT[threadID], CTFsAbs[threadID], !options.PrerotateParticles ? GetAngleInAllTilts(ParticlePositions) : GetParticleAngleInAllTilts(ParticlePositions, ParticleAngles), MagnificationCorrection);
```
the weight for each pixel in the images of tilt series is set to 1. The 3DCTF is reconstructed in a similar way.
Hence, when ```--dont_correct_ctf_3d``` is specified, WARP will export subtomogram reconstructed by backprojecting raw images in tilt series.
    These options are useful for training OPUS-TOMO (https://github.com/alncat/opusTomo), which can often effectively identify target specie from initial particle picks in the initial stages of tomographic data processing. These modifications might be a useful addition to WARP's functions. Any feedbacks will be greatly appreciated!
Sincerely,
Zhenwei Luo