### PR TITLE
preserve input star columns during particle export

### DIFF
--- a/WarpLib/WorkerWrapper.cs
+++ b/WarpLib/WorkerWrapper.cs
@@ -463,7 +463,7 @@ namespace Warp
                                                     angles));
         }
 
-        public void TomoExportParticleSeries(string path, ProcessingOptionsTomoSubReconstruction options, float3[] coordinates, float3[] angles, string pathsRelativeTo, string pathTableOut)
+        public void TomoExportParticleSeries(string path, ProcessingOptionsTomoSubReconstruction options, float3[] coordinates, float3[] angles, string pathsRelativeTo, string pathTableOut, Dictionary<string, string[]> additionalColumns)
         {
             SendCommand(new NamedSerializableObject("TomoExportParticleSeries",
                                                     path,
@@ -471,7 +471,8 @@ namespace Warp
                                                     coordinates,
                                                     angles,
                                                     pathsRelativeTo,
-                                                    pathTableOut));
+                                                    pathTableOut,
+                                                    additionalColumns));
         }
 
         public void MPAPrepareSpecies(string path, string stagingSave)

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -929,23 +929,18 @@ namespace WarpTools.Commands
             List<int> UsedTilts = exportOptions.DoLimitDose
                 ? tiltSeries.IndicesSortedDose.Take(exportOptions.NTilts).ToList()
                 : tiltSeries.IndicesSortedDose.ToList();
+
             float TiltDose;
-            if (UsedTilts.Count == 0) {
-                // No tilts available, use a default value
-                TiltDose = 1.0f; // Default exposure value
-                Console.WriteLine($"Warning: No tilts available for {tiltSeries.Name}, using default dose");
-            } else if (UsedTilts.Count > 1) {
-                // Normal case - calculate dose difference between first two tilts
+            if (UsedTilts.Count <= 1)
+            {
+                // For single tilt, use the absolute dose value instead of a difference
+                TiltDose = UsedTilts.Count == 1 ? tiltSeries.Dose[UsedTilts[0]] : 1.0f;
+                Console.WriteLine($"Using single tilt dose: {TiltDose}");
+            }
+            else
+            {
+                // Normal case - calculate dose difference between tilts
                 TiltDose = tiltSeries.Dose[UsedTilts[1]] - tiltSeries.Dose[UsedTilts[0]];
-            } else {
-                // Single tilt case
-                if (tiltSeries.Dose.Length > UsedTilts[0]) {
-                    TiltDose = tiltSeries.Dose[UsedTilts[0]]; 
-                } else {
-                    // Safety check if Dose array doesn't contain this index
-                    TiltDose = 1.0f;
-                    Console.WriteLine($"Warning: Dose information missing for tilt {UsedTilts[0]} in {tiltSeries.Name}");
-                }
             }
             UsedTilts.Sort();
 

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -926,36 +926,16 @@ namespace WarpTools.Commands
                 "rlnTomoImportFractionalDose"
             });
 
-            List<int> UsedTilts = new List<int>();
-            if (exportOptions.DoLimitDose && tiltSeries.IndicesSortedDose != null && tiltSeries.IndicesSortedDose.Length > 0)
-            {
-                UsedTilts = tiltSeries.IndicesSortedDose.Take(Math.Min(exportOptions.NTilts, tiltSeries.IndicesSortedDose.Length)).ToList();
-            }
-            else if (tiltSeries.IndicesSortedDose != null && tiltSeries.IndicesSortedDose.Length > 0)
-            {
-                UsedTilts = tiltSeries.IndicesSortedDose.ToList();
-            }
-            else
-            {
-                // Fallback in case IndicesSortedDose is null or empty
-                Console.WriteLine($"Warning: No tilt indices available for {tiltSeries.Name}");
-                // Add at least one index if dose array isn't empty
-                if (tiltSeries.Dose != null && tiltSeries.Dose.Length > 0)
-                    UsedTilts.Add(0);
-            }
-
-// Debug information
-            Console.WriteLine($"DEBUG: UsedTilts.Count = {UsedTilts.Count}");
-            if (UsedTilts.Count > 0)
-                Console.WriteLine($"DEBUG: First tilt index = {UsedTilts[0]}");
-
-            float TiltDose = 1.0f; // Default value
-            if (UsedTilts.Count > 0 && tiltSeries.Dose != null && UsedTilts[0] < tiltSeries.Dose.Length)
-            {
-                if (UsedTilts.Count > 1 && UsedTilts[1] < tiltSeries.Dose.Length)
-                    TiltDose = tiltSeries.Dose[UsedTilts[1]] - tiltSeries.Dose[UsedTilts[0]];
-                else
-                    TiltDose = tiltSeries.Dose[UsedTilts[0]];
+            List<int> UsedTilts = exportOptions.DoLimitDose
+                ? tiltSeries.IndicesSortedDose.Take(exportOptions.NTilts).ToList()
+                : tiltSeries.IndicesSortedDose.ToList();
+            float TiltDose;
+            if (UsedTilts.Count > 1) {
+                // Normal case - calculate dose difference between first two tilts
+                TiltDose = tiltSeries.Dose[UsedTilts[1]] - tiltSeries.Dose[UsedTilts[0]];
+            } else {
+                // Single tilt case - use a default value or the dose of the single tilt
+                TiltDose = tiltSeries.Dose[UsedTilts[0]]; // Or another appropriate value
             }
             UsedTilts.Sort();
 

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -929,8 +929,14 @@ namespace WarpTools.Commands
             List<int> UsedTilts = exportOptions.DoLimitDose
                 ? tiltSeries.IndicesSortedDose.Take(exportOptions.NTilts).ToList()
                 : tiltSeries.IndicesSortedDose.ToList();
-            float TiltDose =
-                tiltSeries.Dose[UsedTilts[1]] - tiltSeries.Dose[UsedTilts[0]];
+            float TiltDose;
+            if (UsedTilts.Count > 1) {
+                // Normal case - calculate dose difference between first two tilts
+                TiltDose = tiltSeries.Dose[UsedTilts[1]] - tiltSeries.Dose[UsedTilts[0]];
+            } else {
+                // Single tilt case - use a default value or the dose of the single tilt
+                TiltDose = tiltSeries.Dose[UsedTilts[0]]; // Or another appropriate value
+            }
             UsedTilts.Sort();
 
             tiltSeries.VolumeDimensionsPhysical = exportOptions.DimensionsPhysical;

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -930,12 +930,22 @@ namespace WarpTools.Commands
                 ? tiltSeries.IndicesSortedDose.Take(exportOptions.NTilts).ToList()
                 : tiltSeries.IndicesSortedDose.ToList();
             float TiltDose;
-            if (UsedTilts.Count > 1) {
+            if (UsedTilts.Count == 0) {
+                // No tilts available, use a default value
+                TiltDose = 1.0f; // Default exposure value
+                Console.WriteLine($"Warning: No tilts available for {tiltSeries.Name}, using default dose");
+            } else if (UsedTilts.Count > 1) {
                 // Normal case - calculate dose difference between first two tilts
                 TiltDose = tiltSeries.Dose[UsedTilts[1]] - tiltSeries.Dose[UsedTilts[0]];
             } else {
-                // Single tilt case - use a default value or the dose of the single tilt
-                TiltDose = tiltSeries.Dose[UsedTilts[0]]; // Or another appropriate value
+                // Single tilt case
+                if (tiltSeries.Dose.Length > UsedTilts[0]) {
+                    TiltDose = tiltSeries.Dose[UsedTilts[0]]; 
+                } else {
+                    // Safety check if Dose array doesn't contain this index
+                    TiltDose = 1.0f;
+                    Console.WriteLine($"Warning: Dose information missing for tilt {UsedTilts[0]} in {tiltSeries.Name}");
+                }
             }
             UsedTilts.Sort();
 

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -937,6 +937,7 @@ namespace WarpTools.Commands
                 // Single tilt case - use a default value or the dose of the single tilt
                 TiltDose = tiltSeries.Dose[UsedTilts[0]]; // Or another appropriate value
             }
+            
             UsedTilts.Sort();
 
             tiltSeries.VolumeDimensionsPhysical = exportOptions.DimensionsPhysical;

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -102,6 +102,8 @@ namespace WarpTools.Commands
 
     class ExportParticlesTiltseries : BaseCommand
     {
+        private Dictionary<string, string[]> _additionalColumns;
+
         public override async Task Run(object options)
         {
             await base.Run(options);
@@ -167,6 +169,12 @@ namespace WarpTools.Commands
             }
 
             ValidateInputStar(inputStar);
+            _additionalColumns = new Dictionary<string, string[]>();
+            if (inputStar.HasColumn("rlnUnknownLabel"))
+            {
+                _additionalColumns.Add("rlnUnknownLabel", inputStar.GetColumn("rlnUnknownLabel"));
+            }
+
             string[] tiltSeriesIDs = inputStar.HasColumn("rlnMicrographName") ? inputStar.GetColumn("rlnMicrographName") : inputStar.GetColumn("rlnTomoName");
             Dictionary<string, List<int>> tiltSeriesIdToParticleIndices =
                 GroupParticles(tiltSeriesIDs);
@@ -236,6 +244,21 @@ namespace WarpTools.Commands
                 float3[] tsParticleXyzAngstroms = new float3[tsParticleIdx.Count];
                 float3[] tsParticleRotTiltPsi = new float3[tsParticleIdx.Count];
 
+                Dictionary<string, string[]> tsAdditionalColumns = new Dictionary<string, string[]>();
+                if (_additionalColumns.Count > 0)
+                {
+                    foreach (var col in _additionalColumns)
+                    {
+                        var colData = new string[tsParticleIdx.Count];
+                        for (int i = 0; i < tsParticleIdx.Count; i++)
+                        {
+                            colData[i] = col.Value[tsParticleIdx[i]];
+                        }
+                        tsAdditionalColumns.Add(col.Key, colData);
+                    }
+                }
+
+
                 if (Helper.IsDebug)
                     Console.WriteLine($"{tsParticleIdx.Count} particles for {tiltSeries.Name}");
 
@@ -279,7 +302,8 @@ namespace WarpTools.Commands
                                                                     inputHasEulerAngles: inputHasEulerAngles,
                                                                     outputPixelSize: cli.OutputPixelSize,
                                                                     relativeToParticleStarFile: cli.OutputPathsRelativeToStarFile,
-                                                                    particleStarFile: cli.OutputStarFile);
+                                                                    particleStarFile: cli.OutputStarFile,
+                                                                    additionalColumns: tsAdditionalColumns);
                     lock (OutputStarTables)
                         OutputStarTables.Add(tiltSeries.Name, TiltSeriesTable);
                 }
@@ -302,7 +326,8 @@ namespace WarpTools.Commands
                                                             pathTableOut: TempTiltSeriesParticleStarPath,
                                                             pathsRelativeTo: cli.OutputPathsRelativeToStarFile ?
                                                                                  Path.GetFullPath(OutputStarPath) :
-                                                                                 Directory.GetCurrentDirectory());
+                                                                                 Directory.GetCurrentDirectory(),
+                                                            additionalColumns: tsAdditionalColumns);
 
                             // generate necessary metadata for particles.star
                             if (Helper.IsDebug)
@@ -697,7 +722,8 @@ namespace WarpTools.Commands
             bool inputHasEulerAngles,
             float outputPixelSize,
             bool relativeToParticleStarFile, // default is relative to working directory 
-            string? particleStarFile
+            string? particleStarFile,
+            Dictionary<string, string[]> additionalColumns
         )
         {
             int nParticles = xyz.Length;
@@ -805,6 +831,14 @@ namespace WarpTools.Commands
                 table.RemoveColumn("rlnAngleRot");
                 table.RemoveColumn("rlnAngleTilt");
                 table.RemoveColumn("rlnAnglePsi");
+            }
+
+            if (additionalColumns != null)
+            {
+                foreach (var pair in additionalColumns)
+                {
+                    table.AddColumn(pair.Key, pair.Value);
+                }
             }
 
             return table;

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -326,7 +326,8 @@ namespace WarpTools.Commands
                                                             pathTableOut: TempTiltSeriesParticleStarPath,
                                                             pathsRelativeTo: cli.OutputPathsRelativeToStarFile ?
                                                                                  Path.GetFullPath(OutputStarPath) :
-                                                                                 Directory.GetCurrentDirectory());
+                                                                                 Directory.GetCurrentDirectory(),
+                                                            additionalColumns: tsAdditionalColumns);
 
                             // generate necessary metadata for particles.star
                             if (Helper.IsDebug)

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -170,9 +170,23 @@ namespace WarpTools.Commands
 
             ValidateInputStar(inputStar);
             _additionalColumns = new Dictionary<string, string[]>();
-            if (inputStar.HasColumn("rlnUnknownLabel"))
+            var knownColumns = new HashSet<string>
             {
-                _additionalColumns.Add("rlnUnknownLabel", inputStar.GetColumn("rlnUnknownLabel"));
+                "rlnCoordinateX", "rlnCoordinateY", "rlnCoordinateZ",
+                "rlnMicrographName", "rlnTomoName",
+                "rlnOriginX", "rlnOriginXAngst",
+                "rlnOriginY", "rlnOriginYAngst",
+                "rlnOriginZ", "rlnOriginZAngst",
+                "rlnPixelSize", "rlnImagePixelSize",
+                "rlnAngleRot", "rlnAngleTilt", "rlnAnglePsi",
+                "rlnOpticsGroup", "rlnOpticsGroupName"
+            };
+            foreach (var columnName in inputStar.GetColumnNames())
+            {
+                if (!knownColumns.Contains(columnName))
+                {
+                    _additionalColumns.Add(columnName, inputStar.GetColumn(columnName));
+                }
             }
 
             string[] tiltSeriesIDs = inputStar.HasColumn("rlnMicrographName") ? inputStar.GetColumn("rlnMicrographName") : inputStar.GetColumn("rlnTomoName");

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -326,8 +326,7 @@ namespace WarpTools.Commands
                                                             pathTableOut: TempTiltSeriesParticleStarPath,
                                                             pathsRelativeTo: cli.OutputPathsRelativeToStarFile ?
                                                                                  Path.GetFullPath(OutputStarPath) :
-                                                                                 Directory.GetCurrentDirectory(),
-                                                            additionalColumns: tsAdditionalColumns);
+                                                                                 Directory.GetCurrentDirectory());
 
                             // generate necessary metadata for particles.star
                             if (Helper.IsDebug)

--- a/WarpWorker/WarpWorker.cs
+++ b/WarpWorker/WarpWorker.cs
@@ -76,7 +76,7 @@ namespace WarpWorker
                 webBuilder.UseKestrel(options =>
                     {
                         options.ListenAnyIP(Port);
-                        options.Limits.MaxRequestBodySize = 104857600; // 100 MB
+                        options.Limits.MaxRequestBodySize = 500 * 1024 * 1024; // 100 MB
                     })
                     .UseStartup<RESTStartup>()
                     .ConfigureLogging(logging => logging.SetMinimumLevel(LogLevel.Warning));

--- a/WarpWorker/WarpWorker.cs
+++ b/WarpWorker/WarpWorker.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Hosting;
 using System;
 using System.Diagnostics;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;

--- a/WarpWorker/WarpWorker.cs
+++ b/WarpWorker/WarpWorker.cs
@@ -858,6 +858,19 @@ namespace WarpWorker
 
                     TiltSeries T = new TiltSeries(Path);
                     T.ReconstructParticleSeries(Options, Coordinates, Angles, PathsRelativeTo, out TableOut);
+                    
+                    Dictionary<string, string[]> AdditionalColumns = null;
+                    if (Command.Content.Length > 6)
+                        AdditionalColumns = (Dictionary<string, string[]>)Command.Content[6];
+
+                    if (AdditionalColumns != null)
+                    {
+                        foreach (var col in AdditionalColumns)
+                        {
+                            TableOut.AddColumn(col.Key, col.Value);
+                        }
+                    }
+                    
                     T.SaveMeta();
 
                     if (!string.IsNullOrEmpty(PathTableOut))


### PR DESCRIPTION
This PR tries to solve the issue of preserving fields in the input star file when performing particle export. I was able to inject a dummy field `rlnGoodBoi`
```
data_

loop_
_rlnCoordinateX #1
_rlnCoordinateY #2
_rlnCoordinateZ #3
_rlnMicrographName #4
_rlnAngleRot #5
_rlnAngleTilt #6
_rlnAnglePsi #7
_rlnGoodBoi #8
675.768420  280.329043  186.950708  lam13_pos01_ts_006.tomostar 47.110208   85.968355   76.758127   c69eff2b6fe606fc
767.988150  167.457476  231.917305  lam13_pos01_ts_006.tomostar 57.129510   55.046367   -167.929250 83818753e4382e7e
268.366622  5.933382    179.789018  lam13_pos01_ts_006.tomostar 97.207547   51.317759   172.148981  91d0c1859c546315
605.553549  755.948645  135.947819  lam13_pos01_ts_006.tomostar 69.082745   70.528932   16.758236   8274a3e9f3b8c8aa
467.895984  610.609762  188.689848  lam13_pos01_ts_006.tomostar 101.250318  37.970189   37.852244   4285300587041ff1
365.430149  79.323344   55.399279   lam13_pos01_ts_006.tomostar 82.793697   73.354014   44.883255   d9dd3e0c8d269573
385.810648  145.840924  87.299531   lam13_pos01_ts_006.tomostar 93.516341   71.947021   -178.476110 8cc988bf5b2773ba
519.993252  780.430362  229.882874  lam13_pos01_ts_006.tomostar 117.246614  48.588616   -161.601060 68ddbbff2ab8f0ed
568.081757  772.639943  232.340113  lam13_pos01_ts_006.tomostar 70.121706   38.357151   -24.960290  ec17c39d9001acf3
256.924264  378.316166  57.720800   lam13_pos01_ts_006.tomostar 87.363785   50.549125   166.758366  545ee563a9ebc0cc
```
and preserve it in the output star file after export
```

data_

loop_
_rlnCoordinateX #1
_rlnCoordinateY #2
_rlnCoordinateZ #3
_rlnAngleRot #4
_rlnAngleTilt #5
_rlnAnglePsi #6
_rlnMicrographName #7
_rlnMagnification #8
_rlnDetectorPixelSize #9
_rlnCtfMaxResolution #10
_rlnImageName #11
_rlnCtfImage #12
_rlnPixelSize #13
_rlnVoltage #14
_rlnSphericalAberration #15
_rlnGoodBoi #16
  132.738   84.604  41.529    46.58264   51.69937  -115.19492  lam16_pos01_ts_003.tomostar  10000.0  20.00000  6.2  subtomo/lam16_pos01_ts_003/lam16_pos01_ts_003_0000000_20.00A.mrc  subtomo/lam16_pos01_ts_003/lam16_pos01_ts_003_0000000_ctf_20.00A.mrc  20.00000  300.000  2.700  13d54f207a9afb06
  180.880    9.291  37.853   133.06715   70.52849   101.13314  lam16_pos01_ts_003.tomostar  10000.0  20.00000  6.2  subtomo/lam16_pos01_ts_003/lam16_pos01_ts_003_0000001_20.00A.mrc  subtomo/lam16_pos01_ts_003/lam16_pos01_ts_003_0000001_ctf_20.00A.mrc  20.00000  300.000  2.700  4a9551f863b62de9
 ```