### PR TITLE
Explicitly template and instantiate d_ValueFill function

### DIFF
--- a/NativeAcceleration/gtom/src/Correlation/SimilarityMatrix.cu
+++ b/NativeAcceleration/gtom/src/Correlation/SimilarityMatrix.cu
@@ -38,7 +38,7 @@ namespace gtom
 
 		d_imagesft += ElementsFFT2(dimsimage) * startvalid;
 		d_similarity += startvalid;
-		d_ValueFill(d_similarity, nvalid, (tfloat)-1);
+		d_ValueFill<tfloat>(d_similarity, nvalid, (tfloat)-1);
 
 		for (int i = 0; i < anglesteps; i++)
 		{
@@ -73,7 +73,7 @@ namespace gtom
 		tcomplex* d_target = d_linesft + ElementsFFT2(dimslines) * target;
 		d_linesft += ElementsFFT2(dimslines) * startvalid;
 		d_similarity += startvalid;
-		d_ValueFill(d_similarity, nvalid, (tfloat)-1);
+		d_ValueFill<tfloat>(d_similarity, nvalid, (tfloat)-1);
 
 		for (int i = 0; i < anglesteps; i++)
 		{

--- a/NativeAcceleration/gtom/src/Correlation/SubTomograms.cu
+++ b/NativeAcceleration/gtom/src/Correlation/SubTomograms.cu
@@ -39,8 +39,8 @@ namespace gtom
 		/*if (nvolumes > batchsize)
 			throw;*/
 
-		d_ValueFill(d_bestcorrelation, Elements(dimsvolume) * nvolumes, (tfloat)-1e30);
-		d_ValueFill(d_bestangle, Elements(dimsvolume) * nvolumes, (float)0);
+		d_ValueFill<tfloat>(d_bestcorrelation, Elements(dimsvolume) * nvolumes, (tfloat)-1e30);
+		d_ValueFill<float>(d_bestangle, Elements(dimsvolume) * nvolumes, (float)0);
 
 		tcomplex* d_projectedftctf;
 		cudaMalloc((void**)&d_projectedftctf, ElementsFFT(dimsvolume) * batchsize * sizeof(tcomplex));

--- a/NativeAcceleration/gtom/src/Helpers/Memory.cu
+++ b/NativeAcceleration/gtom/src/Helpers/Memory.cu
@@ -284,12 +284,18 @@ namespace gtom
 		return CudaMallocValueFilled<tfloat>(elements, (tfloat)0.0);
 	}
 
+	// Explicitly instantiate d_ValueFill to prevent linker errors
+	template void d_ValueFill<float>(float* d_array, size_t elements, float value);
+	template void d_ValueFill<float2> (float2* d_array, size_t elements, float2 value);
+	template void d_ValueFill<double>(double* d_array, size_t elements, double value);
+
+
 	template <class T> T* CudaMallocValueFilled(size_t elements, T value)
 	{
 		T* d_array;
 		cudaMalloc((void**)&d_array, elements * sizeof(T));
 
-		d_ValueFill(d_array, elements, value);
+		d_ValueFill<T>(d_array, elements, value);
 
 		return d_array;
 	}

--- a/NativeAcceleration/gtom/src/ImageManipulation/LocalLowpass.cu
+++ b/NativeAcceleration/gtom/src/ImageManipulation/LocalLowpass.cu
@@ -21,7 +21,7 @@ namespace gtom
 	{
 		tcomplex* d_inputft;
 		cudaMalloc((void**)&d_inputft, ElementsFFT(dims) * sizeof(tcomplex));
-		d_ValueFill(d_output, Elements(dims), (tfloat)0);
+		d_ValueFill<tfloat>(d_output, Elements(dims), (tfloat)0);
 		tcomplex* d_maskedft;
 		cudaMalloc((void**)&d_maskedft, ElementsFFT(dims) * sizeof(tcomplex));
 		tfloat* d_cleanresolution;
@@ -63,7 +63,7 @@ namespace gtom
 			tfloat res = (tfloat)b * binsize + minval;
 			tfloat freq = (tfloat)dims.x / res;
 
-			d_ValueFill(d_mask, Elements(dims), (tfloat)1);
+			d_ValueFill<tfloat>(d_mask, Elements(dims), (tfloat)1);
 			d_SphereMask(d_mask, d_mask, dims, &freq, 0, NULL, false);
 			d_RemapFull2HalfFFT(d_mask, d_maskhalf, dims);
 
@@ -93,5 +93,4 @@ namespace gtom
 	////////////////
 	//CUDA kernels//
 	////////////////
-
 }

--- a/NativeAcceleration/src/CTF.cu
+++ b/NativeAcceleration/src/CTF.cu
@@ -49,7 +49,7 @@ __declspec(dllexport) void CreateSpectra(float* d_frame,
 	int pertimegroup = nframes / ctfgrid.z;
 
 	// Temp spectra will be summed up to be averaged later
-	d_ValueFill(d_outputall, ElementsFFT2(dimsregionscaled) * nspectra, 0.0f);
+	d_ValueFill<float>(d_outputall, ElementsFFT2(dimsregionscaled) * nspectra, 0.0f);
 
 	cufftHandle ownplanforw = planforw > 0 ? planforw : d_FFTR2CGetPlan(2, toInt3(dimsregion), norigins);
 	cufftHandle ownplanback = planback > 0 ? planback : d_IFFTC2RGetPlan(2, toInt3(dimsregionscaled), norigins);
@@ -97,7 +97,7 @@ __declspec(dllexport) void CreateSpectra(float* d_frame,
     {
         tfloat* d_tempspectraaccumulated;
         cudaMalloc((void**)&d_tempspectraaccumulated, norigins * ElementsFFT2(dimsregion) * sizeof(tfloat));
-        d_ValueFill(d_tempspectraaccumulated, ElementsFFT2(dimsregion) * norigins, (tfloat)0);
+        d_ValueFill<tfloat>(d_tempspectraaccumulated, ElementsFFT2(dimsregion) * norigins, (tfloat)0);
 
         for (size_t z = 0; z < nframes; z++)
         {

--- a/NativeAcceleration/src/RealspaceProjection.cu
+++ b/NativeAcceleration/src/RealspaceProjection.cu
@@ -12,7 +12,7 @@ __declspec(dllexport) void RealspaceProjectForward(float* d_volume,
 													float3* h_angles,
 													int batch)
 {
-	d_ValueFill(d_projections, Elements2(dimsproj) * batch, 0.0f);
+	d_ValueFill<float>(d_projections, Elements2(dimsproj) * batch, 0.0f);
 
 	glm::mat3* d_matrices;
 	

--- a/NativeAcceleration/src/Tools.cu
+++ b/NativeAcceleration/src/Tools.cu
@@ -651,7 +651,7 @@ __declspec(dllexport) void ProjectNMAPseudoAtoms(float3* d_positions,
 												int2 dimsproj,
 												uint batch)
 {
-	d_ValueFill(d_proj, Elements2(dimsproj) * batch, 0.0f);
+	d_ValueFill<float>(d_proj, Elements2(dimsproj) * batch, 0.0f);
 
     d_ProjNMAPseudoAtoms(d_positions,
 						d_intensities,
@@ -691,7 +691,7 @@ __declspec(dllexport) void ProjectSoftPseudoAtoms(float3* d_positions,
 													int2 dimsproj,
 													uint batch)
 {
-	d_ValueFill(d_proj, Elements2(dimsproj) * batch, 0.0f);
+	d_ValueFill<float>(d_proj, Elements2(dimsproj) * batch, 0.0f);
 
     d_ProjSoftPseudoAtoms(d_positions,
 						d_intensities,
@@ -759,12 +759,12 @@ __declspec(dllexport) void DestroyTexture(unsigned long long textureid, unsigned
 
 __declspec(dllexport) void ValueFill(float* d_input, size_t elements, float value)
 {
-	d_ValueFill(d_input, elements, value);
+	d_ValueFill<float>(d_input, elements, value);
 }
 
 __declspec(dllexport) void ValueFillComplex(float2* d_input, size_t elements, float2 value)
 {
-	d_ValueFill(d_input, elements, value);
+	d_ValueFill<float2>(d_input, elements, value);
 }
 
 __declspec(dllexport) void Real(float2* d_input, float* d_output, size_t elements)


### PR DESCRIPTION
When compiling NativeAcceleration.so, I noticed some linker errors related to the (templated) `d_ValueFill` function:

```
$ nm -C libNativeAcceleration.so | grep d_ValueFill
                 U void gtom::d_ValueFill<float2>(float2*, unsigned long, float2)
                 U void gtom::d_ValueFill<float>(float*, unsigned long, float)
```

As you can see, these are undefined symbols. Reason being is that they aren't being instantiated anywhere.

However, that kinda got my interest why this isn't a problem in the release builds. They ship with a whole hoist of instantiations of the same templated function!
```
$ nm -C libNativeAcceleration.so | grep d_ValueFill
00000000001ba1ea W void gtom::d_ValueFill<int2>(int2*, unsigned long, int2)
00000000001ba2b9 W void gtom::d_ValueFill<int3>(int3*, unsigned long, int3)
00000000001b9d06 W void gtom::d_ValueFill<float2>(float2*, unsigned long, float2)
00000000001ba53c W void gtom::d_ValueFill<gtom::tfloat2>(gtom::tfloat2*, unsigned long, gtom::tfloat2)
00000000001ba611 W void gtom::d_ValueFill<gtom::tfloat3>(gtom::tfloat3*, unsigned long, gtom::tfloat3)
00000000001ba6f7 W void gtom::d_ValueFill<gtom::tfloat4>(gtom::tfloat4*, unsigned long, gtom::tfloat4)
00000000001ba46c W void gtom::d_ValueFill<bool>(bool*, unsigned long, bool)
00000000001b9ddb W void gtom::d_ValueFill<char>(char*, unsigned long, char)
00000000001b9c31 W void gtom::d_ValueFill<double>(double*, unsigned long, double)
00000000001b9b5e W void gtom::d_ValueFill<float>(float*, unsigned long, float)
00000000001b9eab W void gtom::d_ValueFill<unsigned char>(unsigned char*, unsigned long, unsigned char)
00000000001ba11d W void gtom::d_ValueFill<int>(int*, unsigned long, int)
00000000001ba39f W void gtom::d_ValueFill<unsigned int>(unsigned int*, unsigned long, unsigned int)
00000000001b9f7b W void gtom::d_ValueFill<short>(short*, unsigned long, short)
00000000001ba04c W void gtom::d_ValueFill<unsigned short>(unsigned short*, unsigned long, unsigned short)
```

After way too much time debugging this, it turns out that the "release" builds - as available on Conda - are not actually optimized builds. When compiling with `-DCMAKE_RELEASE_TYPE=Release`, all compiler optimizations get switched on and I guess somewhere, some of those implementations get optimized away - as they don't get instantiated anywhere explicitly in the code. When not defining `-DCMAKE_RELEASE_TYPE`, no compiler optimizations get used and it works.
This matches with what I observe in the scripts [here](https://github.com/warpem/warp/blob/main/conda-recipe/build.sh#L16). Another way it could work is that current builds are made with GCC 9. Starting at GCC 10+, link-time template instantiation was [removed](https://gcc.gnu.org/gcc-10/changes.html).

Anyways long story short, this PR adds explicit template instantiations to the NativeAcceleration library, allowing one to compile and link it with compiler optimizations turned on. To stick a little bit more to best practices and aid my debugging, I made the types explicit while I was at it, too. Compiles fine with GCC 10+ now!