### PR TITLE
Fix defects overflow

### DIFF
--- a/WarpLib/WarpWorker.cs
+++ b/WarpLib/WarpWorker.cs
@@ -912,7 +912,7 @@ namespace Warp
                         {
                             GPU.CopyDeviceToDevice(GPULayers[GPUThreadID].GetDevice(Intent.Read),
                                                    GPULayers2[GPUThreadID].GetDevice(Intent.Write),
-                                                   header.Dimensions.Elements());
+                                                   header.Dimensions.ElementsSlice());
                             DefectMap.Correct(GPULayers2[GPUThreadID], GPULayers[GPUThreadID]);
                         }
 

--- a/WarpWorker/WarpWorker.cs
+++ b/WarpWorker/WarpWorker.cs
@@ -1100,7 +1100,7 @@ namespace WarpWorker
                         {
                             GPU.CopyDeviceToDevice(GPULayers[GPUThreadID].GetDevice(Intent.Read),
                                                    GPULayers2[GPUThreadID].GetDevice(Intent.Write),
-                                                   header.Dimensions.Elements());
+                                                   header.Dimensions.ElementsSlice());
                             DefectMap.Correct(GPULayers2[GPUThreadID], GPULayers[GPUThreadID]);
                         }
 


### PR DESCRIPTION
I created a defects file (.mrc) to mask out dead pixel of the detector, but I ran into a very strange issue when trying to use it. When I run the first processing steps to get averages of my tilt movies (fs_motion_and_ctf), it seems only part of the averages have the defects correctly masked out, and it seemed completely random which ones had it correct. And, every time I rerun, the corrected files seem to randomly change without any pattern.

I had Claude go over the codebase and after some back-and-forth it managed to propose this fix... which fixed it :+1: According to Claude it a GPU memory overflow issue and it caused the observed race condition.

@dtegunov let me know if this fix makes sense to you


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected GPU memory transfer sizing during defect correction processing to maintain consistency with slice-based operations, improving data processing accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->