### PR TITLE
Avoid NullReferenceException for WarpWorker help/parse-failure path

### DIFF
--- a/WarpWorker/WarpWorker.cs
+++ b/WarpWorker/WarpWorker.cs
@@ -51,6 +51,9 @@ namespace WarpWorker
             OptionsCLI OptionsCLI = null;
             Parser.Default.ParseArguments<OptionsCLI>(args).WithParsed(opts => OptionsCLI = opts);
 
+            if (OptionsCLI == null)
+                return;
+
             if (OptionsCLI.DebugAttach && !Debugger.IsAttached)
                 Debugger.Launch();
 


### PR DESCRIPTION
Fixes Issue #470.

`WarpWorker --help` currently prints help, then crashes with a `NullReferenceException`.

The parser does not populate `OptionsCLI` for help/version/parse-failure paths, but the code immediately dereferences `OptionsCLI.DebugAttach` and later `OptionsCLI.Device`.

This adds a minimal guard:
```csharp
if (OptionsCLI == null)
    return;
```

before any dereference of OptionsCLI.

Expected behavior after this change:
```bash
WarpWorker --help
```
prints help and exits cleanly.

A normal worker launch with required arguments should continue to work:
```bash
WarpWorker -d 0 -p 5055 --debug
```
