### PR TITLE
Update Norm.cu to fix z coordinate in NormBackgroundMonoKernel mask

### DIFF
--- a/NativeAcceleration/gtom/src/ImageManipulation/Norm.cu
+++ b/NativeAcceleration/gtom/src/ImageManipulation/Norm.cu
@@ -402,7 +402,7 @@ namespace gtom
 			for (int y = 0; y < dims.y; y++)
 				for (int x = threadIdx.x; x < dims.x; x += blockDim.x)
 				{
-					int zz = y - dims.z / 2;
+					int zz = z - dims.z / 2;
 					int yy = y - dims.y / 2;
 					int xx = x - dims.x / 2;
 


### PR DESCRIPTION
Use the z loop variable when computing the centered z coordinate for the particle-radius background mask.

Fixes #481 Question about z-coordinate in NormBackgroundMonoKernel background mask 

This PR applies a minimal one-line fix in:

`NativeAcceleration/gtom/src/ImageManipulation/Norm.cu`

Current code in `NormBackgroundMonoKernel` computes the centered z coordinate as:

```cpp
int zz = y - dims.z / 2;
```
Surrounding loop iterates over z, y, and x, and the voxel access uses the actual z index:
```
tfloat val = d_input[(z * dims.y + y) * dims.x + x];
```
Proposed radius calculation uses the centered coordinates for all three dimensions:
```
int zz = z - dims.z / 2;
int yy = y - dims.y / 2;
int xx = x - dims.x / 2;
```
PR change:
```Diff
- int zz = y - dims.z / 2;
+ int zz = z - dims.z / 2;
```
