### PR TITLE
Preserve custom particle metadata columns in MTools create_species and M

### DIFF
--- a/MTools/Commands/CreateSpecies.cs
+++ b/MTools/Commands/CreateSpecies.cs
@@ -444,6 +444,8 @@ namespace MTools.Commands
                     ParticlesFinal[p].ResampleAngles(Options.TemporalSamples);
                 }
 
+                Species.AttachExtraColumns(ParticlesFinal, TableWarp, Species.IsReservedParticleColumn);
+
                 #endregion
             }
             else if (!string.IsNullOrEmpty(Options.ParticlesRelion))
@@ -629,6 +631,9 @@ namespace MTools.Commands
                     particle.ResampleCoordinates(Options.TemporalSamples);
                     particle.ResampleAngles(Options.TemporalSamples);
                 }
+
+                // Keep only non-RELION (custom) columns, e.g. aisFilamentID; drop all rln* bookkeeping
+                Species.AttachExtraColumns(ParticlesFinal, CleanRelion, n => n.StartsWith("rln", StringComparison.Ordinal));
 
                 #endregion
             }

--- a/WarpLib/Sociology/Particle.cs
+++ b/WarpLib/Sociology/Particle.cs
@@ -48,6 +48,9 @@ namespace Warp.Sociology
 
         public float FOM;
 
+        // Passthrough metadata columns from the input STAR file (key = column name)
+        public Dictionary<string, string> Extra = new Dictionary<string, string>();
+
         public Particle(float3[] coordinates, float3[] angles, int randomSubset, string sourceName, string sourceHash, float fom = 0)
         {
             Coordinates = coordinates;
@@ -193,7 +196,10 @@ namespace Warp.Sociology
 
         public Particle GetCopy()
         {
-            return new Particle(Coordinates.ToArray(), Angles.ToArray(), RandomSubset, SourceName, SourceHash);
+            return new Particle(Coordinates.ToArray(), Angles.ToArray(), RandomSubset, SourceName, SourceHash)
+            {
+                Extra = new Dictionary<string, string>(Extra)
+            };
         }
 
         public bool IsSameMicrograph(Particle other)

--- a/WarpLib/Sociology/Species.cs
+++ b/WarpLib/Sociology/Species.cs
@@ -1066,7 +1066,7 @@ namespace Warp.Sociology
                     string Value = null;
                     particle.Extra?.TryGetValue(columnName, out Value);
                     // Empty tokens would break STAR column alignment, so substitute a placeholder
-                    Row.Add(string.IsNullOrEmpty(Value) ? "0" : Value);
+                    Row.Add(string.IsNullOrEmpty(Value) ? "null" : Value);
                 }
 
                 TableOut.AddRow(Row.ToArray());

--- a/WarpLib/Sociology/Species.cs
+++ b/WarpLib/Sociology/Species.cs
@@ -974,6 +974,31 @@ namespace Warp.Sociology
             Particles = newParticles;
         }
 
+        public static bool IsReservedParticleColumn(string name)
+        {
+            if (name == "wrpRandomSubset" || name == "wrpSourceName" || name == "wrpSourceHash")
+                return true;
+
+            foreach (string prefix in new[] { "wrpCoordinateX", "wrpCoordinateY", "wrpCoordinateZ",
+                                              "wrpAngleRot", "wrpAngleTilt", "wrpAnglePsi" })
+                if (name.StartsWith(prefix) && int.TryParse(name.Substring(prefix.Length), out _))
+                    return true;
+
+            return false;
+        }
+
+        public static void AttachExtraColumns(Particle[] particles, Star table, Func<string, bool> isConsumedColumn)
+        {
+            string[] Names = table.GetColumnNames().Where(n => !isConsumedColumn(n)).ToArray();
+            if (Names.Length == 0)
+                return;
+
+            string[][] Columns = Names.Select(n => table.GetColumn(n)).ToArray();
+            for (int p = 0; p < particles.Length; p++)
+                for (int e = 0; e < Names.Length; e++)
+                    particles[p].Extra[Names[e]] = Columns[e][p];
+        }
+
         public Star ParticlesToStar()
         {
             if (Particles.Length == 0)
@@ -1004,6 +1029,15 @@ namespace Warp.Sociology
             ColumnNames.Add("wrpSourceName");
             ColumnNames.Add("wrpSourceHash");
 
+            List<string> ExtraColumnNames = new List<string>();
+            HashSet<string> ExtraColumnSeen = new HashSet<string>();
+            foreach (var particle in Particles)
+                if (particle.Extra != null)
+                    foreach (var key in particle.Extra.Keys)
+                        if (!IsReservedParticleColumn(key) && ExtraColumnSeen.Add(key))
+                            ExtraColumnNames.Add(key);
+            ColumnNames.AddRange(ExtraColumnNames);
+
             Star TableOut = new Star(ColumnNames.ToArray());
 
             // Create rows
@@ -1026,6 +1060,14 @@ namespace Warp.Sociology
                 Row.Add((particle.RandomSubset + 1).ToString(CultureInfo.InvariantCulture));
                 Row.Add(particle.SourceName);
                 Row.Add(particle.SourceHash);
+
+                foreach (var columnName in ExtraColumnNames)
+                {
+                    string Value = null;
+                    particle.Extra?.TryGetValue(columnName, out Value);
+                    // Empty tokens would break STAR column alignment, so substitute a placeholder
+                    Row.Add(string.IsNullOrEmpty(Value) ? "0" : Value);
+                }
 
                 TableOut.AddRow(Row.ToArray());
             }
@@ -1060,6 +1102,9 @@ namespace Warp.Sociology
             string[] ColumnSourceName = tableIn.GetColumn("wrpSourceName");
             string[] ColumnSourceHash = tableIn.GetColumn("wrpSourceHash");
 
+            string[] ExtraColumnNames = tableIn.GetColumnNames().Where(n => !IsReservedParticleColumn(n)).ToArray();
+            string[][] ExtraColumns = ExtraColumnNames.Select(n => tableIn.GetColumn(n)).ToArray();
+
             Particle[] Result = new Particle[tableIn.RowCount];
 
             for (int p = 0; p < Result.Length; p++)
@@ -1072,6 +1117,9 @@ namespace Warp.Sociology
                                                                          ColumnsAnglePsi[i][p]), TemporalResolutionMovement);
 
                 Result[p] = new Particle(Coordinates, Angles, ColumnSubset[p], ColumnSourceName[p], ColumnSourceHash[p]);
+
+                for (int e = 0; e < ExtraColumnNames.Length; e++)
+                    Result[p].Extra[ExtraColumnNames[e]] = ExtraColumns[e][p];
             }
 
             return Result;


### PR DESCRIPTION
In `2.0.0dev39`, @shahpnmlab's #433 was implemented, which stopped `WarpTools ts_export_particles` from discarding non-standard STAR columns during export. However, `MTools create_species` still drops most of the input STAR file's columns — it keeps only the particle pose (coordinates + Euler angles).

It is often useful to retain custom metadata throughout refinement in M — for example, a flag recording which parent object (filament, membrane/surface, …) a particle belongs to, or per-particle geometric properties such as radius of curvature.

This PR preserves **all custom columns — every column that does not start with `rln`** — through `create_species`, and writes them back whenever MCore saves `<species>_particles.star`. Standard `rln*` bookkeeping is still dropped, since M represents that internally.

**What changed**
- `Particle` gains a `Dictionary<string,string> Extra` holding passthrough columns.
- `create_species`: on RELION import keeps every non-`rln*` column; on M import keeps every non-`wrp*` column.
- `Species.ParticlesToStar` / `ParticlesFromStar` round-trip these columns, so they survive M's per-iteration save/load of the species particle table.
- `Particle.GetCopy` copies `Extra`, so symmetry expansion / rotate / shift / mask-update keep the metadata.

**Testing**
- Tested with `MTools create_species` and MCore.
