### PR TITLE
Feature/extract raw 2d particleseries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## v2.0.0dev39
 
+### New Features
+
+- **`ts_export_particles --extract_raw`**: 2D particle export can now optionally also write non-CTF-premultiplied, non-weighted copies of every particle stack to a `raw/` subdirectory, plus a matching `_raw.star` and `_raw_optimisation_set.star`, for use with tools that expect non-premultiplied particles (e.g. tomoDRGN). Existing output is unchanged when the flag is not passed.
+
 ### Bug Fixes
 
 - **LibTorchSharp ABI mismatch with conda-forge PyTorch**: Removed the `-D_GLIBCXX_USE_CXX11_ABI=0` flag from LibTorchSharp. conda-forge's PyTorch (cuda129 builds) uses the new C++11 ABI, so LibTorchSharp must match. The old ABI flag caused undefined symbol errors for `torch::serialize::InputArchive::read` when MCore loaded LibTorchSharp against the new-ABI libtorch.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## v2.0.0dev39
+## v2.0.0dev40
 
 ### New Features
 
-- **`ts_export_particles --extract_raw`**: 2D particle export can now write non-CTF-premultiplied, non-weighted particle stacks instead of the default CTF-premultiplied output, for use with tools that expect raw particles (e.g. tomoDRGN). Existing output is unchanged when the flag is not passed.
+- **`ts_export_particles --dont_premultiply`**: 2D particle export can now write particle stacks without CTF premultiplication or RELION weighting, for use with tools that expect non-premultiplied particles (e.g. tomoDRGN). Existing output is unchanged when the flag is not passed.
+
+## v2.0.0dev39
 
 ### Bug Fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-- **`ts_export_particles --extract_raw`**: 2D particle export can now optionally also write non-CTF-premultiplied, non-weighted copies of every particle stack to a `raw/` subdirectory, plus a matching `_raw.star` and `_raw_optimisation_set.star`, for use with tools that expect non-premultiplied particles (e.g. tomoDRGN). Existing output is unchanged when the flag is not passed.
+- **`ts_export_particles --extract_raw`**: 2D particle export can now write non-CTF-premultiplied, non-weighted particle stacks instead of the default CTF-premultiplied output, for use with tools that expect raw particles (e.g. tomoDRGN). Existing output is unchanged when the flag is not passed.
 
 ### Bug Fixes
 

--- a/WarpLib/TiltSeries/TiltSeries.ReconstructParticleSeries.cs
+++ b/WarpLib/TiltSeries/TiltSeries.ReconstructParticleSeries.cs
@@ -17,6 +17,10 @@ public partial class TiltSeries
         if (!Directory.Exists(ParticleSeriesDir))
             Directory.CreateDirectory(ParticleSeriesDir);
 
+        string ParticleSeriesRawDir = System.IO.Path.Combine(ParticleSeriesDir, "raw");
+        if (options.ExtractRaw && !Directory.Exists(ParticleSeriesRawDir))
+            Directory.CreateDirectory(ParticleSeriesRawDir);
+
         #region Dimensions
 
         VolumeDimensionsPhysical = options.DimensionsPhysical;
@@ -111,6 +115,16 @@ public partial class TiltSeries
 
         Image SumAllParticles = new Image(new int3(SizeSub, SizeSub, NTilts));
 
+        // Raw (non-CTF-premultiplied, non-weighted) counterparts, only allocated when requested.
+        // GPU.IFFT's underlying cuFFT C2R plan is destructive on its input, so the raw copy must be
+        // IFFT'd from a scratch copy of ImagesFT taken before CTF/weight multiplication, not from
+        // ImagesFT itself, or the corrected output below would be corrupted.
+        Image ImagesRaw = options.ExtractRaw ? new Image(new int3(SizeSub, SizeSub, NTilts)) : null;
+        Image ImagesFTRawScratch = options.ExtractRaw ? new Image(new int3(SizeSub, SizeSub, NTilts), true, true) : null;
+        Image UsedParticlesRaw = options.ExtractRaw ? new Image(new int3(SizeSub, SizeSub, UsedTilts.Count)) : null;
+        float[][] UsedParticlesRawData = options.ExtractRaw ? UsedParticlesRaw.GetHost(Intent.Write) : null;
+        Image SumAllParticlesRaw = options.ExtractRaw ? new Image(new int3(SizeSub, SizeSub, NTilts)) : null;
+
         // Needed as long as we can't specify per-tilt B-factors in tomograms.star
         // B-factors are strictly tied to exposure, and aren't B-factors but Niko's formula
         Image RelionWeights = new Image(new int3(SizeSub, SizeSub, NTilts), true, false);
@@ -145,6 +159,27 @@ public partial class TiltSeries
 
             ImagesFT = GetImagesForOneParticle(options, TiltData, SizeSub, ParticlePositions, PlanForwParticle, -1, 0, false, Images, ImagesFT);
             GetCTFsForOneParticle(options, ParticlePositions, CTFCoords, null, false, false, false, CTFs);
+
+            if (options.ExtractRaw)
+            {
+                // IFFT a scratch copy of the not-yet-multiplied particle FFT. GPU.IFFT's cuFFT C2R
+                // plan is destructive on its input, so ImagesFT itself must stay untouched here for
+                // the corrected path below.
+                GPU.CopyDeviceToDevice(ImagesFT.GetDevice(Intent.Read), ImagesFTRawScratch.GetDevice(Intent.Write), ImagesFT.ElementsReal);
+
+                GPU.IFFT(ImagesFTRawScratch.GetDevice(Intent.Read),
+                    ImagesRaw.GetDevice(Intent.Write),
+                    ImagesFT.Dims.Slice(),
+                    (uint)ImagesFT.Dims.Z,
+                    PlanBackParticle,
+                    false);
+
+                SumAllParticlesRaw.Add(ImagesRaw);
+
+                float[][] ImagesRawData = ImagesRaw.GetHost(Intent.Read);
+                for (int i = 0; i < UsedTilts.Count; i++)
+                    Array.Copy(ImagesRawData[UsedTilts[i]], 0, UsedParticlesRawData[i], 0, ImagesRawData[0].Length);
+            }
 
             ImagesFT.Multiply(CTFs);
             ImagesFT.Multiply(RelionWeights);
@@ -199,6 +234,12 @@ public partial class TiltSeries
 
             UsedParticles.WriteMRC16b(SeriesPath, (float)options.BinnedPixelSizeMean, true);
 
+            if (options.ExtractRaw)
+            {
+                string SeriesPathRaw = System.IO.Path.Combine(ParticleSeriesRawDir, System.IO.Path.GetFileName(SeriesPath));
+                UsedParticlesRaw.WriteMRC16b(SeriesPathRaw, (float)options.BinnedPixelSizeMean, true);
+            }
+
             if (IsCanceled)
                 break;
         }
@@ -213,6 +254,18 @@ public partial class TiltSeries
 
             string SumPath = System.IO.Path.Combine(ProcessingDirectoryName, ToParticleSeriesAveragePath(RootName, options.BinnedPixelSizeMean));
             UsedParticles.WriteMRC16b(SumPath, (float)options.BinnedPixelSizeMean, true);
+
+            if (options.ExtractRaw)
+            {
+                SumAllParticlesRaw.Multiply(1f / Math.Max(1, NParticles));
+
+                float[][] SumAllParticlesRawData = SumAllParticlesRaw.GetHost(Intent.Read);
+                for (int i = 0; i < UsedTilts.Count; i++)
+                    Array.Copy(SumAllParticlesRawData[UsedTilts[i]], 0, UsedParticlesRawData[i], 0, SumAllParticlesRawData[0].Length);
+
+                string SumPathRaw = System.IO.Path.Combine(ParticleSeriesRawDir, System.IO.Path.GetFileName(SumPath));
+                UsedParticlesRaw.WriteMRC16b(SumPathRaw, (float)options.BinnedPixelSizeMean, true);
+            }
         }
 
         #region Teardown
@@ -224,6 +277,14 @@ public partial class TiltSeries
         ImagesFT.Dispose();
         CTFs.Dispose();
         CTFCoords.Dispose();
+
+        if (options.ExtractRaw)
+        {
+            SumAllParticlesRaw.Dispose();
+            UsedParticlesRaw.Dispose();
+            ImagesRaw.Dispose();
+            ImagesFTRawScratch.Dispose();
+        }
 
         GPU.DestroyFFTPlan(PlanForwParticle);
         GPU.DestroyFFTPlan(PlanBackParticle);

--- a/WarpLib/TiltSeries/TiltSeries.ReconstructParticleSeries.cs
+++ b/WarpLib/TiltSeries/TiltSeries.ReconstructParticleSeries.cs
@@ -146,7 +146,7 @@ public partial class TiltSeries
             ImagesFT = GetImagesForOneParticle(options, TiltData, SizeSub, ParticlePositions, PlanForwParticle, -1, 0, false, Images, ImagesFT);
             GetCTFsForOneParticle(options, ParticlePositions, CTFCoords, null, false, false, false, CTFs);
 
-            if (!options.ExtractRaw)
+            if (!options.DontPremultiply)
             {
                 ImagesFT.Multiply(CTFs);
                 ImagesFT.Multiply(RelionWeights);

--- a/WarpLib/TiltSeries/TiltSeries.ReconstructParticleSeries.cs
+++ b/WarpLib/TiltSeries/TiltSeries.ReconstructParticleSeries.cs
@@ -17,10 +17,6 @@ public partial class TiltSeries
         if (!Directory.Exists(ParticleSeriesDir))
             Directory.CreateDirectory(ParticleSeriesDir);
 
-        string ParticleSeriesRawDir = System.IO.Path.Combine(ParticleSeriesDir, "raw");
-        if (options.ExtractRaw && !Directory.Exists(ParticleSeriesRawDir))
-            Directory.CreateDirectory(ParticleSeriesRawDir);
-
         #region Dimensions
 
         VolumeDimensionsPhysical = options.DimensionsPhysical;
@@ -115,16 +111,6 @@ public partial class TiltSeries
 
         Image SumAllParticles = new Image(new int3(SizeSub, SizeSub, NTilts));
 
-        // Raw (non-CTF-premultiplied, non-weighted) counterparts, only allocated when requested.
-        // GPU.IFFT's underlying cuFFT C2R plan is destructive on its input, so the raw copy must be
-        // IFFT'd from a scratch copy of ImagesFT taken before CTF/weight multiplication, not from
-        // ImagesFT itself, or the corrected output below would be corrupted.
-        Image ImagesRaw = options.ExtractRaw ? new Image(new int3(SizeSub, SizeSub, NTilts)) : null;
-        Image ImagesFTRawScratch = options.ExtractRaw ? new Image(new int3(SizeSub, SizeSub, NTilts), true, true) : null;
-        Image UsedParticlesRaw = options.ExtractRaw ? new Image(new int3(SizeSub, SizeSub, UsedTilts.Count)) : null;
-        float[][] UsedParticlesRawData = options.ExtractRaw ? UsedParticlesRaw.GetHost(Intent.Write) : null;
-        Image SumAllParticlesRaw = options.ExtractRaw ? new Image(new int3(SizeSub, SizeSub, NTilts)) : null;
-
         // Needed as long as we can't specify per-tilt B-factors in tomograms.star
         // B-factors are strictly tied to exposure, and aren't B-factors but Niko's formula
         Image RelionWeights = new Image(new int3(SizeSub, SizeSub, NTilts), true, false);
@@ -160,29 +146,11 @@ public partial class TiltSeries
             ImagesFT = GetImagesForOneParticle(options, TiltData, SizeSub, ParticlePositions, PlanForwParticle, -1, 0, false, Images, ImagesFT);
             GetCTFsForOneParticle(options, ParticlePositions, CTFCoords, null, false, false, false, CTFs);
 
-            if (options.ExtractRaw)
+            if (!options.ExtractRaw)
             {
-                // IFFT a scratch copy of the not-yet-multiplied particle FFT. GPU.IFFT's cuFFT C2R
-                // plan is destructive on its input, so ImagesFT itself must stay untouched here for
-                // the corrected path below.
-                GPU.CopyDeviceToDevice(ImagesFT.GetDevice(Intent.Read), ImagesFTRawScratch.GetDevice(Intent.Write), ImagesFT.ElementsReal);
-
-                GPU.IFFT(ImagesFTRawScratch.GetDevice(Intent.Read),
-                    ImagesRaw.GetDevice(Intent.Write),
-                    ImagesFT.Dims.Slice(),
-                    (uint)ImagesFT.Dims.Z,
-                    PlanBackParticle,
-                    false);
-
-                SumAllParticlesRaw.Add(ImagesRaw);
-
-                float[][] ImagesRawData = ImagesRaw.GetHost(Intent.Read);
-                for (int i = 0; i < UsedTilts.Count; i++)
-                    Array.Copy(ImagesRawData[UsedTilts[i]], 0, UsedParticlesRawData[i], 0, ImagesRawData[0].Length);
+                ImagesFT.Multiply(CTFs);
+                ImagesFT.Multiply(RelionWeights);
             }
-
-            ImagesFT.Multiply(CTFs);
-            ImagesFT.Multiply(RelionWeights);
 
             GPU.IFFT(ImagesFT.GetDevice(Intent.Read),
                 Images.GetDevice(Intent.Write),
@@ -234,12 +202,6 @@ public partial class TiltSeries
 
             UsedParticles.WriteMRC16b(SeriesPath, (float)options.BinnedPixelSizeMean, true);
 
-            if (options.ExtractRaw)
-            {
-                string SeriesPathRaw = System.IO.Path.Combine(ParticleSeriesRawDir, System.IO.Path.GetFileName(SeriesPath));
-                UsedParticlesRaw.WriteMRC16b(SeriesPathRaw, (float)options.BinnedPixelSizeMean, true);
-            }
-
             if (IsCanceled)
                 break;
         }
@@ -254,18 +216,6 @@ public partial class TiltSeries
 
             string SumPath = System.IO.Path.Combine(ProcessingDirectoryName, ToParticleSeriesAveragePath(RootName, options.BinnedPixelSizeMean));
             UsedParticles.WriteMRC16b(SumPath, (float)options.BinnedPixelSizeMean, true);
-
-            if (options.ExtractRaw)
-            {
-                SumAllParticlesRaw.Multiply(1f / Math.Max(1, NParticles));
-
-                float[][] SumAllParticlesRawData = SumAllParticlesRaw.GetHost(Intent.Read);
-                for (int i = 0; i < UsedTilts.Count; i++)
-                    Array.Copy(SumAllParticlesRawData[UsedTilts[i]], 0, UsedParticlesRawData[i], 0, SumAllParticlesRawData[0].Length);
-
-                string SumPathRaw = System.IO.Path.Combine(ParticleSeriesRawDir, System.IO.Path.GetFileName(SumPath));
-                UsedParticlesRaw.WriteMRC16b(SumPathRaw, (float)options.BinnedPixelSizeMean, true);
-            }
         }
 
         #region Teardown
@@ -277,14 +227,6 @@ public partial class TiltSeries
         ImagesFT.Dispose();
         CTFs.Dispose();
         CTFCoords.Dispose();
-
-        if (options.ExtractRaw)
-        {
-            SumAllParticlesRaw.Dispose();
-            UsedParticlesRaw.Dispose();
-            ImagesRaw.Dispose();
-            ImagesFTRawScratch.Dispose();
-        }
 
         GPU.DestroyFFTPlan(PlanForwParticle);
         GPU.DestroyFFTPlan(PlanBackParticle);

--- a/WarpLib/TiltSeries/TiltSeries.ReconstructSubtomos.cs
+++ b/WarpLib/TiltSeries/TiltSeries.ReconstructSubtomos.cs
@@ -344,4 +344,5 @@ public class ProcessingOptionsTomoSubReconstruction : TomoProcessingOptionsBase
     [WarpSerializable] public int NTilts { get; set; }
     [WarpSerializable] public bool MakeSparse { get; set; }
     [WarpSerializable] public bool UseCPU { get; set; }
+    [WarpSerializable] public bool ExtractRaw { get; set; } = false;
 }

--- a/WarpLib/TiltSeries/TiltSeries.ReconstructSubtomos.cs
+++ b/WarpLib/TiltSeries/TiltSeries.ReconstructSubtomos.cs
@@ -344,5 +344,5 @@ public class ProcessingOptionsTomoSubReconstruction : TomoProcessingOptionsBase
     [WarpSerializable] public int NTilts { get; set; }
     [WarpSerializable] public bool MakeSparse { get; set; }
     [WarpSerializable] public bool UseCPU { get; set; }
-    [WarpSerializable] public bool ExtractRaw { get; set; } = false;
+    [WarpSerializable] public bool DontPremultiply { get; set; } = false;
 }

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -101,6 +101,11 @@ namespace WarpTools.Commands
                     "Particles not visible in more than this number of tilts will be excluded (only works with --2d)",
                 Default = 5)]
         public int MaxMissingTilts { get; set; }
+
+        [Option("extract_raw",
+                HelpText = 
+                    "In addition to the normal CTF-premultiplied particle series, also write a raw stack into a 'raw/' subdirectory (only works with --2d)")]
+	public bool ExtractRaw { get; set; }
     }
 
     class ExportParticlesTiltseries : BaseCommand
@@ -497,6 +502,7 @@ namespace WarpTools.Commands
 
             ProcessingOptionsTomoSubReconstruction ExportOptions =
                 options.GetProcessingTomoSubReconstruction();
+                ExportOptions.ExtractRaw = cli.ExtractRaw;
             return ExportOptions;
         }
 

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -104,8 +104,8 @@ namespace WarpTools.Commands
 
         [Option("extract_raw",
                 HelpText = 
-                    "In addition to the normal CTF-premultiplied particle series, also write a raw stack into a 'raw/' subdirectory (only works with --2d)")]
-	public bool ExtractRaw { get; set; }
+                    "Write raw, non-CTF-premultiplied 2D particle series instead of the default CTF-premultiplied output")]
+        public bool ExtractRaw { get; set; }
     }
 
     class ExportParticlesTiltseries : BaseCommand
@@ -380,11 +380,15 @@ namespace WarpTools.Commands
                             foreach (var pair in tsAdditionalColumns)
                                 if (!ParticleTable.HasColumn(pair.Key))
                                     ParticleTable.AddColumn(pair.Key, pair.Value);
+                        if (ParticleTable.HasColumn("rlnCtfDataAreCtfPremultiplied"))
+                            ParticleTable.ModifyAllValuesInColumn("rlnCtfDataAreCtfPremultiplied",
+                                                                  v => cli.ExtractRaw ? "0" : "1");
                         Star ParticleOpticsTable = Construct2DOpticsTable(tiltSeries: tiltSeries,
                                                                           tiltSeriesPixelSize: (float)cli.Options.Import.PixelSize,
                                                                           downsamplingFactor: (float)ExportOptions.DownsampleFactor,
                                                                           boxSize: ExportOptions.BoxSize,
-                                                                          opticsGroup: opticsGroup);
+                                                                          opticsGroup: opticsGroup,
+                                                                          premultiplied: !cli.ExtractRaw);
 
                         // generate necessary metadata for tomograms.star
                         Star TomogramsGeneralTable = Construct2DTomogramStarGeneralTable(tiltSeries: tiltSeries,
@@ -399,33 +403,6 @@ namespace WarpTools.Commands
                         OutputStarTables.Add(tiltSeries.RootName + "_optics", ParticleOpticsTable);
                         OutputStarTables.Add(tiltSeries.RootName + "_tomograms_global", TomogramsGeneralTable);
                         OutputStarTables.Add(tiltSeries.RootName + "_tomograms_tiltseries", TomogramsTiltSeriesTable);
-
-                        if (cli.ExtractRaw)
-                        {
-                            // Same particles/geometry as above -- only the image paths (pointing
-                            // at raw/) and the premultiplied flag differ, so the tomogram tables
-                            // are reused as-is and only a parallel particles/optics pair is needed.
-                            Star ParticleTableRaw = Construct2DParticleTableRaw(tempParticleStarPath: TempTiltSeriesParticleStarPath,
-                                                                                opticsGroup: opticsGroup);
-                            if (tsAdditionalColumns != null)
-                                foreach (var pair in tsAdditionalColumns)
-                                    // rlnCtfDataAreCtfPremultiplied is preserved from the input star's
-                                    // (optics-flattened) particle rows like any other unrecognized column,
-                                    // but that value describes the input, not this raw export -- keeping it
-                                    // here would contradict the correct value set in the optics table above.
-                                    if (pair.Key != "rlnCtfDataAreCtfPremultiplied" && !ParticleTableRaw.HasColumn(pair.Key))
-                                        ParticleTableRaw.AddColumn(pair.Key, pair.Value);
-
-                            Star ParticleOpticsTableRaw = Construct2DOpticsTable(tiltSeries: tiltSeries,
-                                                                                tiltSeriesPixelSize: (float)cli.Options.Import.PixelSize,
-                                                                                downsamplingFactor: (float)ExportOptions.DownsampleFactor,
-                                                                                boxSize: ExportOptions.BoxSize,
-                                                                                opticsGroup: opticsGroup,
-                                                                                premultiplied: false);
-
-                            OutputStarTables.Add(tiltSeries.RootName + "_particles_raw", ParticleTableRaw);
-                            OutputStarTables.Add(tiltSeries.RootName + "_optics_raw", ParticleOpticsTableRaw);
-                        }
                     }
 
                     // Add particle count so it makes it into processed_items.json
@@ -529,7 +506,7 @@ namespace WarpTools.Commands
 
             ProcessingOptionsTomoSubReconstruction ExportOptions =
                 options.GetProcessingTomoSubReconstruction();
-                ExportOptions.ExtractRaw = cli.ExtractRaw;
+            ExportOptions.ExtractRaw = cli.ExtractRaw;
             return ExportOptions;
         }
 
@@ -958,27 +935,6 @@ namespace WarpTools.Commands
             return ParticleTable;
         }
 
-        // ReconstructParticleSeries writes the raw counterpart of every corrected
-        // .mrcs file into a "raw/" subdirectory next to it, same filename. The temp
-        // star's rlnImageName already points at the corrected file, so the raw
-        // table just needs that column rewritten to insert "raw/" before the
-        // filename -- no separate temp star from the worker is needed.
-        private Star Construct2DParticleTableRaw(string tempParticleStarPath,
-                                                 int opticsGroup)
-        {
-            Star ParticleTable = Construct2DParticleTable(tempParticleStarPath, opticsGroup);
-            ParticleTable.ModifyAllValuesInColumn("rlnImageName", InsertRawSubdirectory);
-            return ParticleTable;
-        }
-
-        private static string InsertRawSubdirectory(string imagePath)
-        {
-            int lastSlash = imagePath.LastIndexOf('/');
-            return lastSlash < 0
-                ? $"raw/{imagePath}"
-                : imagePath.Substring(0, lastSlash + 1) + "raw/" + imagePath.Substring(lastSlash + 1);
-        }
-
         private Star Construct2DTomogramStarGeneralTable(
             TiltSeries tiltSeries,
             ProcessingOptionsTomoSubReconstruction exportOptions,
@@ -1213,60 +1169,6 @@ namespace WarpTools.Commands
 
                 #endregion
 
-                #region combine info and write out raw particles.star + optimisation set
-
-                bool hasRawOutput = perTiltSeriesTables.Keys.Any(k => k.EndsWith("_particles_raw"));
-                if (hasRawOutput)
-                {
-                    Star tableOpticsRawCombined = new Star(perTiltSeriesTables.Where(
-                                                                                  kvp => kvp.Key.EndsWith("_optics_raw")
-                                                                                 ).ToDictionary(
-                                                                                                kvp => kvp.Key, kvp => kvp.Value
-                                                                                               ).Values.ToArray()
-                                                       );
-                    Star tableParticlesRaw = new Star(perTiltSeriesTables.Where(
-                                                                             kvp => kvp.Key.EndsWith("_particles_raw")
-                                                                            ).ToDictionary(
-                                                                                           kvp => kvp.Key, kvp => kvp.Value
-                                                                                          ).Values.ToArray()
-                                                  );
-
-                    // Same particles as the corrected output (just different image paths and
-                    // premultiplied flag), so apply the identical missing-tilts filter to keep
-                    // the two STAR files' particle sets in lockstep.
-                    tableParticlesRaw.RemoveRowsWhere(
-                                                      columnName: "rlnTomoVisibleFrames",
-                                                      match: s => s
-                                                                  .Trim('[', ']')
-                                                                  .Split(',')
-                                                                  .Select(int.Parse)
-                                                                  .Count(value => value == 0) > maxMissingTilts
-                                                     );
-
-                    string particleStarPathRaw = Path.Combine(particleStarDirectory,
-                                                              Helper.PathToName(particleStarPath) + "_raw.star");
-                    Star.SaveMultitable(
-                                        particleStarPathRaw, new Dictionary<string, Star>()
-                                        {
-                                            { "general", table2DMode },
-                                            { "optics", tableOpticsRawCombined },
-                                            { "particles", tableParticlesRaw }
-                                        }
-                                       );
-
-                    // Geometry/alignment is identical to the corrected export, so the raw
-                    // optimisation set reuses the tomograms.star written above as-is.
-                    string particleFileRaw = Helper.MakePathRelativeTo(particleStarPathRaw, pathsRelativeTo);
-                    string optimisationSetPathRaw = Path.Combine(particleStarDirectory,
-                                                                 Helper.PathToName(particleStarPath) + "_raw_optimisation_set.star");
-                    string contentsRaw = "data_\n" +
-                                        "\n" +
-                                        $"_rlnTomoParticlesFile   {particleFileRaw}\n" +
-                                        $"_rlnTomoTomogramsFile   {tomogramsFile}\n";
-                    File.WriteAllText(path: optimisationSetPathRaw, contents: contentsRaw);
-                }
-
-                #endregion
             }
             else if (outputDimensionality == 3)
             {

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -399,6 +399,29 @@ namespace WarpTools.Commands
                         OutputStarTables.Add(tiltSeries.RootName + "_optics", ParticleOpticsTable);
                         OutputStarTables.Add(tiltSeries.RootName + "_tomograms_global", TomogramsGeneralTable);
                         OutputStarTables.Add(tiltSeries.RootName + "_tomograms_tiltseries", TomogramsTiltSeriesTable);
+
+                        if (cli.ExtractRaw)
+                        {
+                            // Same particles/geometry as above -- only the image paths (pointing
+                            // at raw/) and the premultiplied flag differ, so the tomogram tables
+                            // are reused as-is and only a parallel particles/optics pair is needed.
+                            Star ParticleTableRaw = Construct2DParticleTableRaw(tempParticleStarPath: TempTiltSeriesParticleStarPath,
+                                                                                opticsGroup: opticsGroup);
+                            if (tsAdditionalColumns != null)
+                                foreach (var pair in tsAdditionalColumns)
+                                    if (!ParticleTableRaw.HasColumn(pair.Key))
+                                        ParticleTableRaw.AddColumn(pair.Key, pair.Value);
+
+                            Star ParticleOpticsTableRaw = Construct2DOpticsTable(tiltSeries: tiltSeries,
+                                                                                tiltSeriesPixelSize: (float)cli.Options.Import.PixelSize,
+                                                                                downsamplingFactor: (float)ExportOptions.DownsampleFactor,
+                                                                                boxSize: ExportOptions.BoxSize,
+                                                                                opticsGroup: opticsGroup,
+                                                                                premultiplied: false);
+
+                            OutputStarTables.Add(tiltSeries.RootName + "_particles_raw", ParticleTableRaw);
+                            OutputStarTables.Add(tiltSeries.RootName + "_optics_raw", ParticleOpticsTableRaw);
+                        }
                     }
 
                     // Add particle count so it makes it into processed_items.json
@@ -879,7 +902,8 @@ namespace WarpTools.Commands
             float tiltSeriesPixelSize,
             float downsamplingFactor,
             int boxSize,
-            int opticsGroup
+            int opticsGroup,
+            bool premultiplied = true
         )
         {
             string[] columnNames = new string[]
@@ -905,7 +929,7 @@ namespace WarpTools.Commands
                     { FormattableString.Invariant($"{tiltSeries.CTF.Voltage:F3}") },
                 new string[]
                     { FormattableString.Invariant($"{tiltSeriesPixelSize:F5}") },
-                new string[] { "1" },
+                new string[] { premultiplied ? "1" : "0" },
                 new string[] { "2" },
                 new string[]
                     { FormattableString.Invariant($"{downsamplingFactor:F5}") },
@@ -928,6 +952,27 @@ namespace WarpTools.Commands
             ParticleTable.ModifyAllValuesInColumn("rlnOpticsGroup",
                                                   v => $"{opticsGroup}");
             return ParticleTable;
+        }
+
+        // ReconstructParticleSeries writes the raw counterpart of every corrected
+        // .mrcs file into a "raw/" subdirectory next to it, same filename. The temp
+        // star's rlnImageName already points at the corrected file, so the raw
+        // table just needs that column rewritten to insert "raw/" before the
+        // filename -- no separate temp star from the worker is needed.
+        private Star Construct2DParticleTableRaw(string tempParticleStarPath,
+                                                 int opticsGroup)
+        {
+            Star ParticleTable = Construct2DParticleTable(tempParticleStarPath, opticsGroup);
+            ParticleTable.ModifyAllValuesInColumn("rlnImageName", InsertRawSubdirectory);
+            return ParticleTable;
+        }
+
+        private static string InsertRawSubdirectory(string imagePath)
+        {
+            int lastSlash = imagePath.LastIndexOf('/');
+            return lastSlash < 0
+                ? $"raw/{imagePath}"
+                : imagePath.Substring(0, lastSlash + 1) + "raw/" + imagePath.Substring(lastSlash + 1);
         }
 
         private Star Construct2DTomogramStarGeneralTable(
@@ -1161,6 +1206,61 @@ namespace WarpTools.Commands
                                   $"_rlnTomoParticlesFile   {particleFile}\n" +
                                   $"_rlnTomoTomogramsFile   {tomogramsFile}\n";
                 File.WriteAllText(path: optimisationSetPath, contents: contents);
+
+                #endregion
+
+                #region combine info and write out raw particles.star + optimisation set
+
+                bool hasRawOutput = perTiltSeriesTables.Keys.Any(k => k.EndsWith("_particles_raw"));
+                if (hasRawOutput)
+                {
+                    Star tableOpticsRawCombined = new Star(perTiltSeriesTables.Where(
+                                                                                  kvp => kvp.Key.EndsWith("_optics_raw")
+                                                                                 ).ToDictionary(
+                                                                                                kvp => kvp.Key, kvp => kvp.Value
+                                                                                               ).Values.ToArray()
+                                                       );
+                    Star tableParticlesRaw = new Star(perTiltSeriesTables.Where(
+                                                                             kvp => kvp.Key.EndsWith("_particles_raw")
+                                                                            ).ToDictionary(
+                                                                                           kvp => kvp.Key, kvp => kvp.Value
+                                                                                          ).Values.ToArray()
+                                                  );
+
+                    // Same particles as the corrected output (just different image paths and
+                    // premultiplied flag), so apply the identical missing-tilts filter to keep
+                    // the two STAR files' particle sets in lockstep.
+                    tableParticlesRaw.RemoveRowsWhere(
+                                                      columnName: "rlnTomoVisibleFrames",
+                                                      match: s => s
+                                                                  .Trim('[', ']')
+                                                                  .Split(',')
+                                                                  .Select(int.Parse)
+                                                                  .Count(value => value == 0) > maxMissingTilts
+                                                     );
+
+                    string particleStarPathRaw = Path.Combine(particleStarDirectory,
+                                                              Helper.PathToName(particleStarPath) + "_raw.star");
+                    Star.SaveMultitable(
+                                        particleStarPathRaw, new Dictionary<string, Star>()
+                                        {
+                                            { "general", table2DMode },
+                                            { "optics", tableOpticsRawCombined },
+                                            { "particles", tableParticlesRaw }
+                                        }
+                                       );
+
+                    // Geometry/alignment is identical to the corrected export, so the raw
+                    // optimisation set reuses the tomograms.star written above as-is.
+                    string particleFileRaw = Helper.MakePathRelativeTo(particleStarPathRaw, pathsRelativeTo);
+                    string optimisationSetPathRaw = Path.Combine(particleStarDirectory,
+                                                                 Helper.PathToName(particleStarPath) + "_raw_optimisation_set.star");
+                    string contentsRaw = "data_\n" +
+                                        "\n" +
+                                        $"_rlnTomoParticlesFile   {particleFileRaw}\n" +
+                                        $"_rlnTomoTomogramsFile   {tomogramsFile}\n";
+                    File.WriteAllText(path: optimisationSetPathRaw, contents: contentsRaw);
+                }
 
                 #endregion
             }

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -102,10 +102,10 @@ namespace WarpTools.Commands
                 Default = 5)]
         public int MaxMissingTilts { get; set; }
 
-        [Option("extract_raw",
-                HelpText = 
-                    "Write raw, non-CTF-premultiplied 2D particle series instead of the default CTF-premultiplied output")]
-        public bool ExtractRaw { get; set; }
+        [Option("dont_premultiply",
+                HelpText =
+                    "Don't premultiply 2D particle series by CTFs or RELION weights")]
+        public bool DontPremultiply { get; set; }
     }
 
     class ExportParticlesTiltseries : BaseCommand
@@ -382,13 +382,13 @@ namespace WarpTools.Commands
                                     ParticleTable.AddColumn(pair.Key, pair.Value);
                         if (ParticleTable.HasColumn("rlnCtfDataAreCtfPremultiplied"))
                             ParticleTable.ModifyAllValuesInColumn("rlnCtfDataAreCtfPremultiplied",
-                                                                  v => cli.ExtractRaw ? "0" : "1");
+                                                                  v => cli.DontPremultiply ? "0" : "1");
                         Star ParticleOpticsTable = Construct2DOpticsTable(tiltSeries: tiltSeries,
                                                                           tiltSeriesPixelSize: (float)cli.Options.Import.PixelSize,
                                                                           downsamplingFactor: (float)ExportOptions.DownsampleFactor,
                                                                           boxSize: ExportOptions.BoxSize,
                                                                           opticsGroup: opticsGroup,
-                                                                          premultiplied: !cli.ExtractRaw);
+                                                                          premultiplied: !cli.DontPremultiply);
 
                         // generate necessary metadata for tomograms.star
                         Star TomogramsGeneralTable = Construct2DTomogramStarGeneralTable(tiltSeries: tiltSeries,
@@ -506,7 +506,7 @@ namespace WarpTools.Commands
 
             ProcessingOptionsTomoSubReconstruction ExportOptions =
                 options.GetProcessingTomoSubReconstruction();
-            ExportOptions.ExtractRaw = cli.ExtractRaw;
+            ExportOptions.DontPremultiply = cli.DontPremultiply;
             return ExportOptions;
         }
 

--- a/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
+++ b/WarpTools/Commands/Tiltseries/ExportParticlesTiltseries.cs
@@ -409,7 +409,11 @@ namespace WarpTools.Commands
                                                                                 opticsGroup: opticsGroup);
                             if (tsAdditionalColumns != null)
                                 foreach (var pair in tsAdditionalColumns)
-                                    if (!ParticleTableRaw.HasColumn(pair.Key))
+                                    // rlnCtfDataAreCtfPremultiplied is preserved from the input star's
+                                    // (optics-flattened) particle rows like any other unrecognized column,
+                                    // but that value describes the input, not this raw export -- keeping it
+                                    // here would contradict the correct value set in the optics table above.
+                                    if (pair.Key != "rlnCtfDataAreCtfPremultiplied" && !ParticleTableRaw.HasColumn(pair.Key))
                                         ParticleTableRaw.AddColumn(pair.Key, pair.Value);
 
                             Star ParticleOpticsTableRaw = Construct2DOpticsTable(tiltSeries: tiltSeries,


### PR DESCRIPTION
Summary
  ts_export_particles currently only writes CTF-premultiplied, dose-weighted 2D
  particle series. There's no way to get a raw/unweighted copy out, which tools
  like tomoDRGN expect. This adds an additive, opt-in --extract_raw flag 
  (2D only) that writes a second copy alongside the existing output, without
  touching existing behavior.

Implementation note

  GPU.IFFT's cuFFT C2R plan is destructive on its input, so the raw copy is
  IFFT'd from a scratch copy of the particle FFT taken before CTF/weight
  multiplication, the corrected path's ImagesFT buffer is never touched by
  the new code.