### PR TITLE
Disabled cross-validation to speed up etomo patch tracking

### DIFF
--- a/WarpLib/WarpWorker.cs
+++ b/WarpLib/WarpWorker.cs
@@ -387,6 +387,7 @@ namespace Warp
                                     $"comparam.align.tiltalign.MagOption = 0\n" +
                                     $"comparam.align.tiltalign.TiltOption = 0\n" +
                                     $"comparam.align.tiltalign.RotOption = {RotOption}\n" +
+                                    $"comparam.restrictalign.restrictalign.UseCrossValidation = 0\n" +    
                                     $"comparam.align.tiltalign.RobustFitting = 1\n" +
                                     $"comparam.align.tiltalign.WeightWholeTracks = 1\n";
                     File.WriteAllText(path: DirectiveFile, contents: BRTConfig);
@@ -491,6 +492,7 @@ namespace Warp
                                     $"comparam.align.tiltalign.MagOption = 0\n" +
                                     $"comparam.align.tiltalign.TiltOption = 0\n" +
                                     $"comparam.align.tiltalign.RotOption = {RotOption}\n" +
+                                    $"comparam.restrictalign.restrictalign.UseCrossValidation = 0\n" +    
                                     $"comparam.align.tiltalign.RobustFitting = 1\n" +
                                     $"comparam.align.tiltalign.WeightWholeTracks = 1\n";
 

--- a/WarpWorker/WarpWorker.cs
+++ b/WarpWorker/WarpWorker.cs
@@ -623,6 +623,7 @@ namespace WarpWorker
                                     $"comparam.align.tiltalign.MagOption = 0\n" +
                                     $"comparam.align.tiltalign.TiltOption = 0\n" +
                                     $"comparam.align.tiltalign.RotOption = {RotOption}\n" +
+                                    $"comparam.restrictalign.restrictalign.UseCrossValidation = 0\n" +
                                     $"comparam.align.tiltalign.RobustFitting = 1\n" +
                                     $"comparam.align.tiltalign.WeightWholeTracks = 1\n";
                     File.WriteAllText(path: DirectiveFile, contents: BRTConfig);
@@ -721,6 +722,7 @@ namespace WarpWorker
                                     $"comparam.align.tiltalign.MagOption = 0\n" +
                                     $"comparam.align.tiltalign.TiltOption = 0\n" +
                                     $"comparam.align.tiltalign.RotOption = {RotOption}\n" +
+                                    $"comparam.restrictalign.restrictalign.UseCrossValidation = 0\n" +
                                     $"comparam.align.tiltalign.RobustFitting = 1\n" +
                                     $"comparam.align.tiltalign.WeightWholeTracks = 1\n";
 

--- a/WarpWorker2/Commands/TomoExternal.cs
+++ b/WarpWorker2/Commands/TomoExternal.cs
@@ -144,6 +144,7 @@ static partial class WorkerProcess
                         $"comparam.align.tiltalign.MagOption = 0\n" +
                         $"comparam.align.tiltalign.TiltOption = 0\n" +
                         $"comparam.align.tiltalign.RotOption = {RotOption}\n" +
+                        $"comparam.restrictalign.restrictalign.UseCrossValidation = 0\n" +           
                         $"comparam.align.tiltalign.RobustFitting = 1\n" +
                         $"comparam.align.tiltalign.WeightWholeTracks = 1\n";
 
@@ -231,6 +232,7 @@ static partial class WorkerProcess
                         $"comparam.align.tiltalign.MagOption = 0\n" +
                         $"comparam.align.tiltalign.TiltOption = 0\n" +
                         $"comparam.align.tiltalign.RotOption = {RotOption}\n" +
+                        $"comparam.restrictalign.restrictalign.UseCrossValidation = 0\n" +    
                         $"comparam.align.tiltalign.RobustFitting = 1\n" +
                         $"comparam.align.tiltalign.WeightWholeTracks = 1\n";
         File.WriteAllText(path: DirectiveFile, contents: BRTConfig);


### PR DESCRIPTION
Just added batchruntomo directives to disable cross-validation, speeding up the patch tracking procedure.