### PR TITLE
Fix Linux liblion CPU FFTW header/runtime mismatch

### DIFF
--- a/NativeAcceleration/CMakeLists.txt
+++ b/NativeAcceleration/CMakeLists.txt
@@ -5,7 +5,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 
 
 FIND_PACKAGE(Threads REQUIRED)
-FIND_PACKAGE(FFTW COMPONENTS FLOAT_THREADS_LIB REQUIRED)
+# liblion uses CPU FFTW's single-precision interface on Linux.
+FIND_PACKAGE(FFTW COMPONENTS FLOAT_LIB FLOAT_THREADS_LIB REQUIRED)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -17,7 +18,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 INCLUDE(FindTIFF)
 
-INCLUDE_DIRECTORIES(include ${PROJECT_SOURCE_DIR})
+INCLUDE_DIRECTORIES(include ${PROJECT_SOURCE_DIR} ${FFTW_INCLUDE_DIRS})
 INCLUDE_DIRECTORIES("${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}") 
 
 FILE(GLOB_RECURSE SOURCES src/*.cu src/*.cpp gtom/src/*.cu gtom/src/*.cpp liblion/*.cpp liblion/*.cc)
@@ -50,4 +51,13 @@ set_target_properties(NativeAcceleration PROPERTIES CUDA_ARCHITECTURES "61;70;75
 # libcudart.so is intentionally listed explicitly so the linker records a direct SONAME
 # dependency rather than relying on libcufft.so's transitive pull, which guarantees the
 # dynamic linker loads exactly one libcudart.so instance regardless of link order.
-TARGET_LINK_LIBRARIES(NativeAcceleration ${FFTW_LIBRARIES} libtiff.so libcudart.so libcufft.so libcublas.so libcurand.so ${CMAKE_THREAD_LIBS_INIT})
+# liblion resolves fftwf_* through CPU FFTW; gtom GPU FFT paths remain on native cuFFT.
+TARGET_LINK_LIBRARIES(NativeAcceleration
+    ${FFTW_FLOAT_THREADS_LIB}
+    ${FFTW_FLOAT_LIB}
+    libtiff.so
+    libcudart.so
+    libcufft.so
+    libcublas.so
+    libcurand.so
+    ${CMAKE_THREAD_LIBS_INIT})

--- a/NativeAcceleration/liblion/fftw.h
+++ b/NativeAcceleration/liblion/fftw.h
@@ -46,8 +46,18 @@
 #ifndef __XmippFFTW_H
 #define __XmippFFTW_H
 
+#ifdef _WIN32
 #include <cufftw.h>
-//#include <cufftw.h>
+#else
+#include <fftw3.h>
+
+static_assert(FFTW_MEASURE == 0U,
+              "Unexpected FFTW_MEASURE value; CPU fftw3.h is required");
+static_assert(FFTW_DESTROY_INPUT == (1U << 0),
+              "Unexpected FFTW_DESTROY_INPUT value; CPU fftw3.h is required");
+static_assert(FFTW_ESTIMATE == (1U << 6),
+              "Unexpected FFTW_ESTIMATE value; CPU fftw3.h is required");
+#endif
 #include "multidim_array.h"
 #include "funcs.h"
 #include "tabfuncs.h"


### PR DESCRIPTION
Hi @dtegunov, I was curious what you thought of this potential way to address the "all scores exactly 0" Stage-1 failure during some MTools/MCore refinements, e.g., in Issue #480 Dramatic resolution drop (5.7 A > 11.2 A) after CTF refinement in MCore. Developed in conjunction with a LLM.

## Summary
On Linux, `NativeAcceleration/liblion/fftw.h` includes NVIDIA's
`cufftw.h`, while the Linux NativeAcceleration build resolves the
`fftwf_*` symbols through CPU FFTW.

This creates a header/runtime mismatch in the liblion reference-projector
path. This PR makes the Linux liblion path compile against CPU
`fftw3.h` and makes the single-precision CPU FFTW dependency explicit.

Warp's genuine gtom GPU FFT paths remain on native cuFFT. The existing
Windows `cufftw.h` path is preserved unchanged and was not tested.

## Observed failure

In a reproducible Linux MCore workflow at `SizeRefine=128`, repeated
geometry refinements eventually produced reference scores exactly equal
to zero.

The observed failure pattern included:

- `AB = 0`
- `A2 = 0`
- `B2 > 0`
- `Final score = 0`

Diagnostic testing showed that the real reference input and Fourier
output buffer were overwritten during FFTW plan creation. The liblion
code requested `FFTW_ESTIMATE`, but the translation unit was compiled
with the cuFFTW compatibility header while its calls were resolved
through CPU FFTW.

## Changes

- Use `fftw3.h` for the Linux liblion/reference-projector path.
- Preserve the existing `cufftw.h` include under `_WIN32`.
- Add compile-time checks for:
  - `FFTW_MEASURE`
  - `FFTW_DESTROY_INPUT`
  - `FFTW_ESTIMATE`
- Require the CPU single-precision FFTW core component explicitly.
- Add the discovered FFTW include directory.
- Link the single-precision CPU FFTW components explicitly.
- Leave gtom native-cuFFT code unchanged.
- Leave the already-upstream shared-cudart and inverse-cuFFT corrections
  unchanged.

## Exact current-main PR-commit validation

Validated commit:

`c6b96cab37f00258a1a15b4b3f30a992583e1f6c`

The exact commit submitted in this PR was rebuilt on Linux and passed:

- generated `fftw.cpp.o.d` records the intended `fftw3.h`;
- the dependency file contains no Linux `cufftw.h`;
- `liblion/fftw.cpp.o` references CPU `fftwf_*` symbols;
- representative gtom FFT objects retain native `cufft*` references;
- `libNativeAcceleration.so` loads `libfftw3f.so`,
  `libcufft.so`, and shared `libcudart.so`;
- `libNativeAcceleration.so` does not load `libcufftw.so`;
- `ldd -r` reports no unresolved dependency or symbol;
- a standalone `128^3` `FFTW_ESTIMATE` test preserved both the
  planning input and output sentinel and produced nonzero Fourier output;
- Warp's exported CPU FFT round trip passed at `128^3`;
- two consecutive `InitProjector` calls at `128^3` produced finite,
  nonzero, repeatable output while preserving the input array.

## End-to-end MCore regression evidence

The end-to-end MCore regression was performed with an official
v2.0.0dev39-based Linux build containing this CPU-FFTW correction plus
several separately audited, unrelated fixes.

Those unrelated fixes did not modify the liblion FFTW planner path. To
isolate the code submitted here, the exact current-main PR commit was
separately rebuilt and passed the tests listed above.

The same repeated geometry-refinement sequence that had previously
transitioned to exact-zero reference scores completed with finite,
nonzero scores and reported global resolutions of:

- 4.08 Å
- 3.81 Å
- 3.74 Å
- 3.71 Å

Across the archived acceptance series:

- 12 MCore diagnostic runs completed;
- 60/60 per-tilt-series refinement logs ended with `Finished refining`;
- 60/60 final scores were finite and positive;
- 8,554 optimization-score values were parsed;
- zero exact-zero optimization scores were observed;
- no `Final score: 0` occurrence was observed;
- no NaN, infinity, CUDA/cuFFT exception, or unresolved-native-library
  error was detected.

The absolute resolution values are dataset-specific. The relevant
regression result is that the formerly reproducible exact-zero transition
did not recur.

## Platform and build environment

- Rocky Linux 8.5
- x86-64
- CUDA 12.9 build/runtime environment
- .NET 10
- validation host: 8 × NVIDIA RTX 3090

## Scope

This PR addresses only the Linux liblion CPU-FFTW header/runtime
mismatch. It does not change MCore scheduling, particle-refinement
algorithms, STAR handling, normalization, CTF optimization, shared
cudart handling, or native gtom cuFFT behavior.

A compact audit and complete diagnostic logs are available on request.

Linking to Issue #497 Source build: FFTW plan creation can zero the MCore reference projector and produce exact-zero scores